### PR TITLE
refactor: Rename simple-vm-* scenarios to vm-*

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,7 @@ All repos are siblings in a common parent directory:
 │   │   │   └── file.py   # DownloadFileAction, RemoveImageAction
 │   │   ├── scenarios/    # Workflow definitions
 │   │   │   ├── nested_pve.py        # nested-pve-{constructor,destructor,roundtrip}
-│   │   │   ├── simple_vm.py         # simple-vm-{constructor,destructor,roundtrip}
+│   │   │   ├── vm.py                # vm-{constructor,destructor,roundtrip}
 │   │   │   ├── pve_configure.py     # pve-configure (local/remote)
 │   │   │   ├── bootstrap.py         # bootstrap-install
 │   │   │   └── cleanup_nested_pve.py # Shared cleanup actions
@@ -511,11 +511,11 @@ The orchestrator runs scenarios composed of reusable actions:
 # Run only destructor (cleanup existing environment)
 ./run.sh --scenario nested-pve-destructor --host father --inner-ip 10.0.12.x
 
-# Simple VM test (deploy, verify SSH, destroy)
-./run.sh --scenario simple-vm-roundtrip --host father
+# VM test (deploy, verify SSH, destroy)
+./run.sh --scenario vm-roundtrip --host father
 
 # Deploy custom environment (multi-VM)
-./run.sh --scenario simple-vm-constructor --host father --env ansible-test
+./run.sh --scenario vm-constructor --host father --env ansible-test
 
 # Configure PVE host (local)
 ./run.sh --scenario pve-configure --local
@@ -591,9 +591,9 @@ The `latest` tag is maintained by the packer release process (see packer#5).
 | `packer-sync` | 1 | Sync local packer to remote |
 | `packer-sync-build-fetch` | 3 | Sync, build, fetch (dev workflow) |
 | `pve-configure` | 2 | Configure PVE host (pve-setup + user) |
-| `simple-vm-constructor` | 5 | Ensure image, provision VM, verify SSH |
-| `simple-vm-destructor` | 1 | Destroy test VM |
-| `simple-vm-roundtrip` | 6 | Full cycle: construct → verify → destruct |
+| `vm-constructor` | 5 | Ensure image, provision VM, verify SSH |
+| `vm-destructor` | 1 | Destroy VM |
+| `vm-roundtrip` | 6 | Full cycle: construct → verify → destruct |
 
 **nested-pve-roundtrip runtime: ~8.5 minutes**
 

--- a/src/scenarios/__init__.py
+++ b/src/scenarios/__init__.py
@@ -102,7 +102,7 @@ def list_scenarios() -> list[str]:
 
 # Import scenarios to trigger registration
 from scenarios import nested_pve  # noqa: E402, F401
-from scenarios import simple_vm  # noqa: E402, F401
+from scenarios import vm  # noqa: E402, F401
 from scenarios import cleanup_nested_pve  # noqa: E402, F401
 from scenarios import pve_configure  # noqa: E402, F401
 from scenarios import bootstrap  # noqa: E402, F401

--- a/src/scenarios/vm.py
+++ b/src/scenarios/vm.py
@@ -1,6 +1,6 @@
-"""Simple VM test scenario.
+"""VM lifecycle scenarios.
 
-Deploys a single VM, verifies SSH access, then destroys it.
+Deploys VMs, verifies SSH access, and destroys them.
 """
 
 import time
@@ -84,11 +84,11 @@ class EnsureImageAction:
 
 
 @register_scenario
-class SimpleVMConstructor:
+class VMConstructor:
     """Deploy a VM and verify SSH access."""
 
-    name = 'simple-vm-constructor'
-    description = 'Ensure image, provision test VM, verify SSH access'
+    name = 'vm-constructor'
+    description = 'Ensure image, provision VM, verify SSH access'
 
     def get_phases(self, config: HostConfig) -> list[tuple[str, object, str]]:
         """Return phases for simple VM deployment."""
@@ -122,11 +122,11 @@ class SimpleVMConstructor:
 
 
 @register_scenario
-class SimpleVMDestructor:
-    """Destroy a test VM."""
+class VMDestructor:
+    """Destroy a VM."""
 
-    name = 'simple-vm-destructor'
-    description = 'Stop and destroy test VM'
+    name = 'vm-destructor'
+    description = 'Destroy VM'
 
     def get_phases(self, config: HostConfig) -> list[tuple[str, object, str]]:
         """Return phases for simple VM destruction."""
@@ -139,11 +139,11 @@ class SimpleVMDestructor:
 
 
 @register_scenario
-class SimpleVMRoundtrip:
+class VMRoundtrip:
     """Full roundtrip: deploy, verify, destroy."""
 
-    name = 'simple-vm-roundtrip'
-    description = 'Deploy test VM, verify SSH, destroy (full cycle)'
+    name = 'vm-roundtrip'
+    description = 'Deploy VM, verify SSH, destroy (full cycle)'
 
     def get_phases(self, config: HostConfig) -> list[tuple[str, object, str]]:
         """Return phases for full roundtrip test."""


### PR DESCRIPTION
## Summary

Renames VM lifecycle scenarios to follow the `noun-verb` naming convention.

## Changes

| Old Name | New Name |
|----------|----------|
| `simple-vm-constructor` | `vm-constructor` |
| `simple-vm-destructor` | `vm-destructor` |
| `simple-vm-roundtrip` | `vm-roundtrip` |

### Files Modified

- `src/scenarios/simple_vm.py` → `src/scenarios/vm.py`
- Class renames: `SimpleVMConstructor` → `VMConstructor`, etc.
- `src/scenarios/__init__.py` - Updated import
- `CLAUDE.md` - Updated references

## Testing

```bash
./run.sh --list-scenarios | grep vm-
# vm-constructor: Ensure image, provision VM, verify SSH access
# vm-destructor: Destroy VM
# vm-roundtrip: Deploy VM, verify SSH, destroy (full cycle)
```

## Related Issues

- Closes #51
- Enables .github#17 (downstream updates for site-config#21)

🤖 Generated with [Claude Code](https://claude.com/claude-code)