### PR TITLE
Update terminology: E2E → integration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -290,7 +290,7 @@ Node configuration merges in `tofu/envs/common/locals.tf`:
 ### Ansible Role Hierarchy
 - Core playbooks: `pve-setup.yml`, `user.yml`, `pve-install.yml`
 - Core roles: base, users, security, proxmox, pve-install
-- E2E roles: pve-iac (generic IaC tools), nested-pve (E2E test config)
+- integration roles: pve-iac (generic IaC tools), nested-pve (integration test config)
 - Environment-specific variables in `inventory/group_vars/`
 
 ## Conventions
@@ -405,7 +405,7 @@ make decrypt  # Decrypt secrets (requires age key)
 
 **Snippets Content Type Required**: Cloud-init user-data files require `snippets` content type on local datastore. Run `pvesm set local -content images,rootdir,vztmpl,backup,iso,snippets`. Handled in ansible `nested-pve` role.
 
-**Claude Code Autonomy**: For fully autonomous E2E test runs, add these to Claude Code allowed tools:
+**Claude Code Autonomy**: For fully autonomous integration test runs, add these to Claude Code allowed tools:
 ```
 Bash(ansible-playbook:*), Bash(ansible:*), Bash(rsync:*)
 ```
@@ -470,13 +470,13 @@ Operations use tiered timeouts based on expected duration. Scenarios can overrid
 
 ### Tuning Guidelines
 
-- **Monitor actual durations**: E2E test reports include phase timings - use these to tune
+- **Monitor actual durations**: integration test reports include phase timings - use these to tune
 - **Nested operations multiply**: Remote tofu = SSH + init + apply timeouts
 - **Guest agent is slow**: First boot can take 60-90s for agent to respond
 - **PVE install varies**: Network speed affects apt, allow 20+ min buffer
 - **Override in scenarios**: When a phase needs more time, override the default explicitly
 
-## E2E Nested PVE Testing
+## integration Nested PVE Testing
 
 End-to-end testing uses nested virtualization to validate the full stack: VM provisioning → PVE installation → nested VM creation.
 
@@ -503,7 +503,7 @@ The orchestrator runs scenarios composed of reusable actions:
 # List phases for a scenario
 ./run.sh --scenario nested-pve-roundtrip --list-phases
 
-# Run full E2E roundtrip (construct, verify, destruct)
+# Run full integration roundtrip (construct, verify, destruct)
 ./run.sh --scenario nested-pve-roundtrip --host father --verbose
 
 # Run only constructor (leave environment running)
@@ -662,9 +662,9 @@ roles:
   - homestak.proxmox.api_token
 ```
 
-### E2E Testing Role
+### integration Testing Role
 
-**nested-pve** - E2E test configuration (in `../ansible/roles/nested-pve/`):
+**nested-pve** - integration test configuration (in `../ansible/roles/nested-pve/`):
 
 Depends on `homestak.debian.iac_tools` and `homestak.proxmox.api_token`:
 - `network.yml` - Configure vmbr0 bridge (required after Debian→PVE conversion)

--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ Options:
 - `simple-vm-constructor` - Deploy and verify SSH (~30s)
 - `simple-vm-destructor` - Destroy test VM (~3s)
 - `simple-vm-roundtrip` - Deploy, verify SSH, destroy (~33s)
-- `nested-pve-constructor` - Provision inner PVE for E2E (~10 min)
+- `nested-pve-constructor` - Provision inner PVE for integration testing (~10 min)
 - `nested-pve-destructor` - Cleanup inner PVE (~30s)
-- `nested-pve-roundtrip` - Full nested PVE E2E test (~12 min)
+- `nested-pve-roundtrip` - Full nested PVE integration test (~12 min)
 
 ## Secrets Management
 

--- a/docs/father-run-improvement-plan.md
+++ b/docs/father-run-improvement-plan.md
@@ -74,7 +74,7 @@ The run.sh script is pre-approved. If all orchestration goes through it, no addi
 **C. Hybrid approach (recommended):**
 1. Pre-approve ansible/rsync in Claude Code settings
 2. Refactor scenarios to minimize direct shell commands
-3. Use run.sh for all E2E testing
+3. Use run.sh for all integration testing
 
 ### 4. Scenario Execution Path
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -4,7 +4,7 @@ Utility scripts for the homestak IaC project.
 
 ## generate-test-summary.sh
 
-Generates a markdown summary of an end-to-end nested PVE test run.
+Generates a markdown summary of an integration nested PVE test run.
 
 ### Usage
 
@@ -13,7 +13,7 @@ Generates a markdown summary of an end-to-end nested PVE test run.
 ./generate-test-summary.sh
 
 # Specify test name and inner PVE IP
-./generate-test-summary.sh nested-pve-e2e 10.0.12.195
+./generate-test-summary.sh nested-pve-integration 10.0.12.195
 ```
 
 ### Output

--- a/src/scenarios/cleanup_nested_pve.py
+++ b/src/scenarios/cleanup_nested_pve.py
@@ -1,6 +1,6 @@
 """Cleanup scenario for nested PVE environment.
 
-Destroys the inner PVE VM and any test VMs created during E2E testing.
+Destroys the inner PVE VM and any test VMs created during integration testing.
 """
 
 import time

--- a/src/scenarios/nested_pve.py
+++ b/src/scenarios/nested_pve.py
@@ -25,14 +25,14 @@ from scenarios.cleanup_nested_pve import StopVMAction
 
 @register_scenario
 class NestedPVEConstructor:
-    """E2E test for nested Proxmox VE installation."""
+    """integration test for nested Proxmox VE installation."""
 
     name = 'nested-pve-constructor'
     description = 'Provision inner PVE, install Proxmox VE, create test VM, verify SSH'
     expected_runtime = 360  # ~6 min (PVE install ~2m with pre-installed image)
 
     def get_phases(self, config: HostConfig) -> list[tuple[str, object, str]]:
-        """Return phases for nested PVE E2E test."""
+        """Return phases for nested PVE integration test."""
         return [
             # Phase 1: Provision inner PVE VM
             ('provision', TofuApplyAction(
@@ -136,7 +136,7 @@ class NestedPVEConstructor:
 
 @register_scenario
 class NestedPVERoundtrip:
-    """Full E2E roundtrip: construct, verify, destruct."""
+    """Full integration roundtrip: construct, verify, destruct."""
 
     name = 'nested-pve-roundtrip'
     description = 'Full cycle: provision, install PVE, test VM, verify, cleanup, destroy'


### PR DESCRIPTION
## Summary

Standardize on "integration test" terminology per .github#12.

## Changes

- README.md: scenario descriptions
- CLAUDE.md: all E2E references
- docs/father-run-improvement-plan.md
- scripts/README.md
- src/scenarios/nested_pve.py: docstrings
- src/scenarios/cleanup_nested_pve.py: docstrings

## Rationale

Per .github CLAUDE.md Terminology section:
> Our tests validate component integration, not user journeys

## Related Issues

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)