### PR TITLE
Fix CLI help text: pve-configure → pve-setup

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -77,11 +77,11 @@ def main():
     parser.add_argument(
         '--local',
         action='store_true',
-        help='Run scenario locally (for pve-configure, packer-build)'
+        help='Run scenario locally (for pve-setup, packer-build)'
     )
     parser.add_argument(
         '--remote',
-        help='Target host IP for remote execution (for pve-configure, packer-build)'
+        help='Target host IP for remote execution (for pve-setup, packer-build)'
     )
     parser.add_argument(
         '--templates',
@@ -230,7 +230,7 @@ def main():
     if args.env:
         orchestrator.context['env_name'] = args.env
 
-    # Pre-populate context for pve-configure and packer-build scenarios
+    # Pre-populate context for pve-setup and packer-build scenarios
     if args.local:
         orchestrator.context['local_mode'] = True
     if args.remote:


### PR DESCRIPTION
## Summary

Fix discrepancy found during CLAUDE.md accuracy check.

## Changes

The CLI help text incorrectly referenced "pve-configure" but the actual
scenario is named "pve-setup". Fixed in 3 locations:
- --local flag help
- --remote flag help
- Context pre-population comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)