### PR TITLE
v0.13: Add resolve_ansible_vars and readiness checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,22 @@
+# Pre-commit hooks for code quality
+# Install: make install-dev && pre-commit install
+# Run manually: pre-commit run --all-files
+
+repos:
+  - repo: local
+    hooks:
+      - id: pylint
+        name: pylint
+        entry: pylint
+        language: system
+        types: [python]
+        args: ['--rcfile=.pylintrc']
+        files: ^src/
+
+      - id: mypy
+        name: mypy
+        entry: mypy
+        language: system
+        types: [python]
+        args: ['--config-file=mypy.ini']
+        files: ^src/

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,14 @@
 # iac-driver Makefile
 
-.PHONY: help install-deps
+.PHONY: help install-deps install-dev test lint
 
 help:
 	@echo "iac-driver - Infrastructure orchestration engine"
 	@echo ""
 	@echo "  make install-deps  - Install required system packages"
+	@echo "  make install-dev   - Install development dependencies (pre-commit, linters)"
+	@echo "  make test          - Run unit tests"
+	@echo "  make lint          - Run pre-commit hooks (pylint, mypy)"
 	@echo ""
 	@echo "Secrets Management:"
 	@echo "  Secrets are managed in the site-config repository."
@@ -18,3 +21,17 @@ install-deps:
 	@apt-get update -qq
 	@apt-get install -y -qq python3 python3-yaml > /dev/null
 	@echo "Done."
+
+install-dev:
+	@echo "Installing development dependencies..."
+	pip install pre-commit pylint mypy types-PyYAML types-requests pytest
+	pre-commit install
+	@echo "Done. Pre-commit hooks installed."
+
+test:
+	@echo "Running unit tests..."
+	cd tests && python -m pytest -v
+
+lint:
+	@echo "Running pre-commit hooks..."
+	pre-commit run --all-files

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,14 @@
+[mypy]
+python_version = 3.11
+warn_return_any = True
+warn_unused_configs = True
+ignore_missing_imports = True
+
+# Strict mode for src/
+[mypy-src.*]
+disallow_untyped_defs = False
+check_untyped_defs = True
+
+# Ignore test files
+[mypy-tests.*]
+ignore_errors = True

--- a/src/readiness.py
+++ b/src/readiness.py
@@ -1,0 +1,135 @@
+"""Pre-flight readiness checks for scenarios.
+
+Validates infrastructure prerequisites before executing actions:
+- API token validity
+- Host resolution and reachability
+"""
+
+import socket
+
+try:
+    import requests
+    import urllib3
+    # Suppress SSL warnings for self-signed certs
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+    REQUESTS_AVAILABLE = True
+except ImportError:
+    REQUESTS_AVAILABLE = False
+
+
+def validate_api_token(api_endpoint: str, api_token: str) -> tuple[bool, str]:
+    """Validate Proxmox API token before running tofu.
+
+    Makes a lightweight API call to verify credentials are valid.
+
+    Args:
+        api_endpoint: PVE API URL (e.g., https://10.0.12.61:8006)
+        api_token: Full token string (e.g., root@pam!homestak=uuid)
+
+    Returns:
+        (success, message) tuple
+    """
+    if not REQUESTS_AVAILABLE:
+        return True, "Skipping API validation (requests not installed)"
+
+    try:
+        resp = requests.get(
+            f"{api_endpoint}/api2/json/version",
+            headers={"Authorization": f"PVEAPIToken={api_token}"},
+            verify=False,  # Self-signed cert
+            timeout=10
+        )
+
+        if resp.status_code == 401:
+            return False, (
+                "Invalid API token. "
+                "Regenerate with: pveum user token add root@pam homestak --privsep 0\n"
+                "Then update secrets.yaml and run: make encrypt"
+            )
+
+        if resp.status_code == 200:
+            data = resp.json().get("data", {})
+            version = data.get("version", "unknown")
+            return True, f"PVE API accessible (version {version})"
+
+        return False, f"Unexpected API response: {resp.status_code} - {resp.text[:100]}"
+
+    except requests.exceptions.ConnectionError as e:
+        return False, f"Cannot connect to {api_endpoint}: {e}"
+    except requests.exceptions.Timeout:
+        return False, f"Timeout connecting to {api_endpoint}"
+    except Exception as e:
+        return False, f"Error validating token: {e}"
+
+
+def validate_host_resolvable(hostname: str) -> tuple[bool, str]:
+    """Check if hostname resolves to an IP address.
+
+    Args:
+        hostname: Hostname or IP to resolve
+
+    Returns:
+        (success, message) tuple
+    """
+    try:
+        ip = socket.gethostbyname(hostname)
+        return True, f"{hostname} resolves to {ip}"
+    except socket.gaierror:
+        return False, (
+            f"Cannot resolve hostname '{hostname}'. "
+            f"Check nodes/{hostname}.yaml or use --host with a resolvable hostname."
+        )
+
+
+def validate_host_reachable(host: str, port: int = 22, timeout: float = 5.0) -> tuple[bool, str]:
+    """Check if host is reachable on specified port.
+
+    Args:
+        host: Hostname or IP
+        port: Port to check (default: 22 for SSH)
+        timeout: Connection timeout in seconds
+
+    Returns:
+        (success, message) tuple
+    """
+    try:
+        sock = socket.create_connection((host, port), timeout=timeout)
+        sock.close()
+        return True, f"Host {host} reachable on port {port}"
+    except socket.timeout:
+        return False, f"Timeout connecting to {host}:{port}"
+    except socket.error as e:
+        return False, f"Cannot connect to {host}:{port}: {e}"
+
+
+def validate_host(hostname: str, check_ssh: bool = True, check_api: bool = False) -> tuple[bool, str]:
+    """Combined host validation.
+
+    Args:
+        hostname: Hostname or IP to validate
+        check_ssh: Check SSH port 22 (for ansible)
+        check_api: Check HTTPS port 8006 (for API)
+
+    Returns:
+        (success, message) tuple
+    """
+    # First check resolution
+    success, message = validate_host_resolvable(hostname)
+    if not success:
+        return False, message
+
+    ip = socket.gethostbyname(hostname)
+
+    # Check SSH
+    if check_ssh:
+        success, ssh_msg = validate_host_reachable(ip, port=22)
+        if not success:
+            return False, f"Host {hostname} ({ip}) SSH not reachable: {ssh_msg}"
+
+    # Check API
+    if check_api:
+        success, api_msg = validate_host_reachable(ip, port=8006)
+        if not success:
+            return False, f"Host {hostname} ({ip}) API port not reachable: {api_msg}"
+
+    return True, f"Host {hostname} ({ip}) reachable"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,197 @@
+"""Shared pytest fixtures for iac-driver tests."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Add src to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent / 'src'))
+
+
+@pytest.fixture
+def site_config_dir(tmp_path):
+    """Create temporary site-config directory structure.
+
+    Creates minimal site-config with:
+    - site.yaml (defaults)
+    - secrets.yaml (mock secrets)
+    - nodes/test-node.yaml
+    - envs/test.yaml
+    - vms/presets/small.yaml
+    - vms/debian-12.yaml
+    - postures/dev.yaml
+    - postures/prod.yaml
+    """
+    # Create directories
+    for d in ['nodes', 'envs', 'vms', 'vms/presets', 'postures', 'hosts']:
+        (tmp_path / d).mkdir(parents=True, exist_ok=True)
+
+    # Create site.yaml (v0.13: packages and pve settings)
+    (tmp_path / 'site.yaml').write_text("""
+defaults:
+  timezone: America/Denver
+  bridge: vmbr0
+  ssh_user: root
+  gateway: 10.0.12.1
+  packages:
+    - htop
+    - curl
+    - wget
+  pve_remove_subscription_nag: true
+""")
+
+    # Create secrets.yaml
+    (tmp_path / 'secrets.yaml').write_text("""
+api_tokens:
+  test-node: "user@pam!token=secret"
+passwords:
+  vm_root: "$6$rounds=4096$hash"
+ssh_keys:
+  key1: "ssh-rsa AAAA... user1"
+  key2: "ssh-ed25519 AAAA... user2"
+""")
+
+    # Create node config (datastore required)
+    (tmp_path / 'nodes/test-node.yaml').write_text("""
+node: test-node
+api_endpoint: https://10.0.12.100:8006
+api_token: test-node
+datastore: local-zfs
+""")
+
+    # Create postures
+    (tmp_path / 'postures/dev.yaml').write_text("""
+ssh_port: 22
+ssh_permit_root_login: "yes"
+ssh_password_authentication: "yes"
+sudo_nopasswd: true
+fail2ban_enabled: false
+packages:
+  - net-tools
+  - strace
+""")
+
+    (tmp_path / 'postures/prod.yaml').write_text("""
+ssh_port: 22
+ssh_permit_root_login: "no"
+ssh_password_authentication: "no"
+sudo_nopasswd: false
+fail2ban_enabled: true
+packages: []
+""")
+
+    # Create preset
+    (tmp_path / 'vms/presets/small.yaml').write_text("""
+cores: 1
+memory: 2048
+disk: 20
+""")
+
+    # Create template
+    (tmp_path / 'vms/debian-12.yaml').write_text("""
+preset: small
+image: debian-12-custom.img
+packages:
+  - qemu-guest-agent
+""")
+
+    # Create environment (with posture FK)
+    (tmp_path / 'envs/test.yaml').write_text("""
+posture: dev
+vmid_base: 99900
+vms:
+  - name: test1
+    template: debian-12
+    ip: 10.0.12.100/24
+  - name: test2
+    template: debian-12
+    ip: dhcp
+  - name: test3
+    template: debian-12
+    cores: 2
+    vmid: 99999
+""")
+
+    return tmp_path
+
+
+@pytest.fixture
+def site_config_without_datastore(tmp_path):
+    """Site config with node missing datastore (for error tests)."""
+    for d in ['nodes', 'envs', 'vms']:
+        (tmp_path / d).mkdir(parents=True, exist_ok=True)
+
+    (tmp_path / 'site.yaml').write_text("""
+defaults:
+  timezone: UTC
+""")
+
+    (tmp_path / 'secrets.yaml').write_text("""
+api_tokens: {}
+""")
+
+    # Node WITHOUT datastore - should trigger error
+    (tmp_path / 'nodes/bad-node.yaml').write_text("""
+node: bad-node
+api_endpoint: https://10.0.12.100:8006
+""")
+
+    (tmp_path / 'envs/test.yaml').write_text("""
+vmid_base: 99900
+vms: []
+""")
+
+    return tmp_path
+
+
+@pytest.fixture
+def site_config_without_posture(tmp_path):
+    """Site config with env missing posture FK (for fallback tests)."""
+    for d in ['nodes', 'envs', 'vms', 'postures']:
+        (tmp_path / d).mkdir(parents=True, exist_ok=True)
+
+    (tmp_path / 'site.yaml').write_text("""
+defaults:
+  timezone: America/Denver
+  packages: []
+""")
+
+    (tmp_path / 'secrets.yaml').write_text("""
+api_tokens:
+  test-node: "token"
+ssh_keys: {}
+""")
+
+    (tmp_path / 'nodes/test-node.yaml').write_text("""
+node: test-node
+api_endpoint: https://10.0.12.100:8006
+datastore: local-zfs
+""")
+
+    # Dev posture for fallback
+    (tmp_path / 'postures/dev.yaml').write_text("""
+ssh_port: 22
+sudo_nopasswd: true
+packages: []
+""")
+
+    # Env WITHOUT posture - should fall back to dev
+    (tmp_path / 'envs/no-posture.yaml').write_text("""
+vmid_base: 99900
+vms: []
+""")
+
+    return tmp_path
+
+
+@pytest.fixture
+def mock_context():
+    """Common context dict for action tests."""
+    return {
+        'inner_ip': '10.0.12.100',
+        'provisioned_vms': [
+            {'name': 'test1', 'vmid': 99900},
+        ],
+        'test1_vm_id': 99900,
+    }

--- a/tests/test_readiness.py
+++ b/tests/test_readiness.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Tests for readiness checks."""
+
+import sys
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, str(Path(__file__).parent.parent / 'src'))
+
+import pytest
+from readiness import (
+    validate_api_token,
+    validate_host_resolvable,
+    validate_host_reachable,
+    validate_host,
+)
+
+
+class TestValidateApiToken:
+    """Test API token validation."""
+
+    def test_valid_token_returns_success(self):
+        """Valid token returns success with version."""
+        with patch('readiness.requests.get') as mock_get:
+            mock_get.return_value.status_code = 200
+            mock_get.return_value.json.return_value = {
+                "data": {"version": "8.1.3"}
+            }
+
+            success, message = validate_api_token(
+                "https://localhost:8006",
+                "root@pam!homestak=abc123"
+            )
+
+            assert success is True
+            assert "8.1.3" in message
+
+    def test_invalid_token_returns_failure(self):
+        """Invalid token returns failure with remediation."""
+        with patch('readiness.requests.get') as mock_get:
+            mock_get.return_value.status_code = 401
+
+            success, message = validate_api_token(
+                "https://localhost:8006",
+                "root@pam!bad=token"
+            )
+
+            assert success is False
+            assert "Invalid API token" in message
+            assert "pveum user token add" in message
+
+    def test_connection_error_returns_failure(self):
+        """Connection error returns descriptive failure."""
+        with patch('readiness.requests.get') as mock_get:
+            mock_get.side_effect = Exception("Connection refused")
+
+            success, message = validate_api_token(
+                "https://badhost:8006",
+                "token"
+            )
+
+            assert success is False
+            assert "Error" in message or "refused" in message.lower()
+
+    def test_timeout_returns_failure(self):
+        """Timeout returns descriptive failure."""
+        with patch('readiness.requests.get') as mock_get:
+            import requests
+            mock_get.side_effect = requests.exceptions.Timeout()
+
+            success, message = validate_api_token(
+                "https://slowhost:8006",
+                "token"
+            )
+
+            assert success is False
+            assert "Timeout" in message
+
+
+class TestValidateHostResolvable:
+    """Test hostname resolution validation."""
+
+    def test_localhost_resolves(self):
+        """localhost should resolve."""
+        success, message = validate_host_resolvable("localhost")
+        assert success is True
+        assert "resolves to" in message
+
+    def test_ip_address_resolves(self):
+        """IP address should resolve to itself."""
+        success, message = validate_host_resolvable("127.0.0.1")
+        assert success is True
+
+    def test_invalid_hostname_fails(self):
+        """Non-existent hostname should fail."""
+        success, message = validate_host_resolvable("nonexistent.invalid.local")
+        assert success is False
+        assert "Cannot resolve" in message
+
+
+class TestValidateHostReachable:
+    """Test host reachability validation."""
+
+    def test_unreachable_port_fails(self):
+        """Unreachable port returns failure."""
+        # Use a high port that's unlikely to be in use
+        success, message = validate_host_reachable("127.0.0.1", port=59999, timeout=1)
+        assert success is False
+
+    def test_reachable_check_structure(self):
+        """Verify return structure."""
+        # Just verify we get a tuple back
+        result = validate_host_reachable("127.0.0.1", port=59999, timeout=0.5)
+        assert isinstance(result, tuple)
+        assert len(result) == 2
+        assert isinstance(result[0], bool)
+        assert isinstance(result[1], str)
+
+
+class TestValidateHost:
+    """Test combined host validation."""
+
+    def test_localhost_resolution(self):
+        """localhost should at least resolve."""
+        # Skip SSH/API checks since they may not be available
+        with patch('readiness.validate_host_reachable') as mock_reach:
+            mock_reach.return_value = (True, "reachable")
+            success, message = validate_host("localhost", check_ssh=True, check_api=False)
+            assert success is True
+
+    def test_invalid_host_fails_early(self):
+        """Invalid hostname should fail at resolution."""
+        success, message = validate_host("nonexistent.invalid.local")
+        assert success is False
+        assert "Cannot resolve" in message
+
+    def test_ssh_check_included(self):
+        """SSH port should be checked when requested."""
+        with patch('readiness.validate_host_resolvable') as mock_resolve:
+            with patch('readiness.validate_host_reachable') as mock_reach:
+                with patch('readiness.socket.gethostbyname') as mock_dns:
+                    mock_resolve.return_value = (True, "resolves")
+                    mock_reach.return_value = (False, "port closed")
+                    mock_dns.return_value = "10.0.0.1"
+
+                    success, message = validate_host("testhost", check_ssh=True, check_api=False)
+
+                    # Should have called reachable check for SSH port 22
+                    mock_reach.assert_called()
+                    # Check that port=22 was passed (either positional or keyword)
+                    call_args = mock_reach.call_args
+                    port = call_args.kwargs.get('port', call_args.args[1] if len(call_args.args) > 1 else None)
+                    assert port == 22
+
+    def test_api_check_included(self):
+        """API port should be checked when requested."""
+        with patch('readiness.validate_host_resolvable') as mock_resolve:
+            with patch('readiness.validate_host_reachable') as mock_reach:
+                with patch('readiness.socket.gethostbyname') as mock_dns:
+                    mock_resolve.return_value = (True, "resolves")
+                    mock_reach.return_value = (True, "reachable")
+                    mock_dns.return_value = "10.0.0.1"
+
+                    success, message = validate_host("testhost", check_ssh=False, check_api=True)
+
+                    # Should have called reachable check for API port 8006
+                    mock_reach.assert_called()
+                    call_args = mock_reach.call_args
+                    port = call_args.kwargs.get('port', call_args.args[1] if len(call_args.args) > 1 else None)
+                    assert port == 8006


### PR DESCRIPTION
## Summary

**ConfigResolver:**
- Add `resolve_ansible_vars()` for ansible variable resolution
- Add `write_ansible_vars()` method
- Add posture loading from `site-config/postures/`
- Add package merging (site + posture, deduplicated)
- Make datastore required from node config (clear error if missing)
- Add `list_postures()` method

**Readiness checks (`src/readiness.py`):**
- Add `validate_api_token()` for API token validation
- Add `validate_host_resolvable()` for DNS resolution
- Add `validate_host_reachable()` for port availability
- Add `validate_host()` combined check

**Test infrastructure:**
- Add `tests/conftest.py` with shared fixtures
- Add `.pre-commit-config.yaml` for pylint/mypy
- Add `mypy.ini` configuration
- Update Makefile with install-dev and lint targets

## Test plan
- [x] Integration test: nested-pve-roundtrip passed (301.7s)
- [x] Unit tests: 28 config_resolver tests passed
- [x] Unit tests: 13 readiness tests passed

Closes #70, #71, #31, #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)