### PR TITLE
Add --dry-run mode for scenario preview (#40)

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -120,6 +120,11 @@ def main():
         metavar='NAME=VMID',
         help='Override VM ID (repeatable): --vm-id test=99990 --vm-id inner=99912'
     )
+    parser.add_argument(
+        '--dry-run',
+        action='store_true',
+        help='Show what would be executed without running actions'
+    )
 
     args = parser.parse_args()
 
@@ -216,7 +221,8 @@ def main():
         config=config,
         report_dir=args.report_dir,
         skip_phases=args.skip,
-        timeout=args.timeout
+        timeout=args.timeout,
+        dry_run=args.dry_run
     )
 
     # Load context from file if specified and exists


### PR DESCRIPTION
## Summary
- Add `--dry-run` flag to CLI for previewing scenarios without execution
- Show phases, actions, and parameters without running anything
- Useful for release verification and understanding scenario behavior

## Changes
- `src/cli.py`: Add `--dry-run` argument
- `src/scenarios/__init__.py`: Add `preview()` method to Orchestrator, handle dry_run flag in `run()`

## Test plan
- [ ] Run `./run.sh --scenario vm-roundtrip --host father --dry-run`
- [ ] Verify no VMs created, only preview output shown
- [ ] Verify phase names, descriptions, and action types displayed

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)