### PR TITLE
Add pre-flight validation and enhanced --local config

### DIFF
--- a/src/validation.py
+++ b/src/validation.py
@@ -1,0 +1,245 @@
+"""Pre-flight validation checks for scenarios.
+
+This module provides readiness checks that run before scenarios execute,
+catching configuration issues early with actionable error messages.
+"""
+
+import logging
+import socket
+
+import requests
+import urllib3
+
+# Suppress SSL warnings for self-signed certs
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+logger = logging.getLogger(__name__)
+
+
+# -----------------------------------------------------------------------------
+# API Token Validation
+# -----------------------------------------------------------------------------
+
+def validate_api_token(api_endpoint: str, api_token: str, node_name: str) -> list[str]:
+    """Validate Proxmox API token is present and valid.
+
+    Args:
+        api_endpoint: PVE API URL (e.g., https://10.0.12.61:8006)
+        api_token: Full token string (e.g., root@pam!homestak=uuid)
+        node_name: Node name for error messages
+
+    Returns:
+        List of validation error messages (empty if valid)
+    """
+    errors = []
+
+    # Check API endpoint is configured
+    if not api_endpoint:
+        errors.append(
+            f"API endpoint not configured for node '{node_name}'\n"
+            f"  Add 'api_endpoint' to site-config/nodes/{node_name}.yaml"
+        )
+        return errors
+
+    # Check token is present
+    if not api_token:
+        errors.append(
+            f"API token not found for node '{node_name}'\n"
+            f"  Ensure secrets.yaml is decrypted: cd ../site-config && make decrypt\n"
+            f"  Ensure token exists: secrets.api_tokens.{node_name}"
+        )
+        return errors
+
+    # Check token format (PVE format: user@realm!tokenname=tokenvalue)
+    if '!' not in api_token or '=' not in api_token:
+        errors.append(
+            f"API token for '{node_name}' has invalid format\n"
+            f"  Expected: user@realm!tokenname=tokenvalue\n"
+            f"  Got: {api_token[:20]}..."
+        )
+        return errors
+
+    # Validate token against API
+    try:
+        resp = requests.get(
+            f"{api_endpoint}/api2/json/version",
+            headers={"Authorization": f"PVEAPIToken={api_token}"},
+            verify=False,  # Self-signed cert
+            timeout=10
+        )
+
+        if resp.status_code == 401:
+            errors.append(
+                f"API token invalid for node '{node_name}'\n"
+                f"  Regenerate: pveum user token add root@pam homestak --privsep 0\n"
+                f"  Then update secrets.yaml and run: cd ../site-config && make encrypt"
+            )
+        elif resp.status_code != 200:
+            errors.append(
+                f"Unexpected API response for node '{node_name}': {resp.status_code}\n"
+                f"  Response: {resp.text[:100]}"
+            )
+        else:
+            data = resp.json().get("data", {})
+            version = data.get("version", "unknown")
+            logger.info(f"API token valid for {node_name} (PVE {version})")
+
+    except requests.exceptions.ConnectionError:
+        errors.append(
+            f"Cannot connect to {api_endpoint}\n"
+            f"  Check: host is online, port 8006 is open, firewall allows access"
+        )
+    except requests.exceptions.Timeout:
+        errors.append(f"Timeout connecting to {api_endpoint}")
+    except Exception as e:
+        errors.append(f"Error validating token: {e}")
+
+    return errors
+
+
+# -----------------------------------------------------------------------------
+# Host Availability Validation
+# -----------------------------------------------------------------------------
+
+def validate_host_resolvable(hostname: str) -> tuple[bool, str]:
+    """Check if hostname resolves to an IP address.
+
+    Args:
+        hostname: Hostname or IP to resolve
+
+    Returns:
+        (success, ip_or_error) tuple
+    """
+    try:
+        ip = socket.gethostbyname(hostname)
+        return True, ip
+    except socket.gaierror:
+        return False, f"Cannot resolve hostname '{hostname}'"
+
+
+def validate_host_reachable(host: str, port: int = 22, timeout: float = 5.0) -> tuple[bool, str]:
+    """Check if host is reachable on specified port.
+
+    Args:
+        host: Hostname or IP
+        port: Port to check (default: 22 for SSH)
+        timeout: Connection timeout in seconds
+
+    Returns:
+        (success, message) tuple
+    """
+    try:
+        sock = socket.create_connection((host, port), timeout=timeout)
+        sock.close()
+        return True, f"Port {port} reachable"
+    except socket.timeout:
+        return False, f"Timeout connecting to {host}:{port}"
+    except socket.error as e:
+        return False, f"Cannot connect to {host}:{port}: {e}"
+
+
+def validate_host_availability(ssh_host: str, node_name: str,
+                               check_ssh: bool = True,
+                               check_api: bool = True,
+                               timeout: float = 5.0) -> list[str]:
+    """Validate host is resolvable and reachable.
+
+    Args:
+        ssh_host: Hostname or IP to validate
+        node_name: Node name for error messages
+        check_ssh: Check SSH port 22
+        check_api: Check API port 8006
+        timeout: Connection timeout per check
+
+    Returns:
+        List of validation error messages (empty if valid)
+    """
+    errors = []
+
+    if not ssh_host:
+        errors.append(
+            f"SSH host not configured for node '{node_name}'\n"
+            f"  Derived from api_endpoint or set explicitly in nodes/{node_name}.yaml"
+        )
+        return errors
+
+    # Check hostname resolution
+    success, result = validate_host_resolvable(ssh_host)
+    if not success:
+        errors.append(
+            f"{result}\n"
+            f"  Check: nodes/{node_name}.yaml has correct api_endpoint or ip\n"
+            f"  Or use --host with a resolvable hostname/IP"
+        )
+        return errors  # Can't check ports if hostname doesn't resolve
+
+    ip = result
+    logger.info(f"Host {ssh_host} resolves to {ip}")
+
+    # Check SSH port
+    if check_ssh:
+        success, message = validate_host_reachable(ip, port=22, timeout=timeout)
+        if not success:
+            errors.append(
+                f"SSH not available on {ssh_host} ({ip})\n"
+                f"  {message}\n"
+                f"  Check: host is online, SSH is enabled, firewall allows port 22"
+            )
+
+    # Check API port
+    if check_api:
+        success, message = validate_host_reachable(ip, port=8006, timeout=timeout)
+        if not success:
+            errors.append(
+                f"PVE API not available on {ssh_host} ({ip})\n"
+                f"  {message}\n"
+                f"  Check: pveproxy service is running, firewall allows port 8006"
+            )
+
+    return errors
+
+
+# -----------------------------------------------------------------------------
+# Combined Validation
+# -----------------------------------------------------------------------------
+
+def validate_readiness(config, scenario_class, timeout: float = 10.0) -> list[str]:
+    """Run all readiness checks for a scenario.
+
+    Args:
+        config: HostConfig instance
+        scenario_class: Scenario class with requirement attributes
+        timeout: Connection timeout for network checks
+
+    Returns:
+        Combined list of all validation errors
+    """
+    errors = []
+
+    # Check scenario requirements
+    requires_api = getattr(scenario_class, 'requires_api', True)
+    requires_host_ssh = getattr(scenario_class, 'requires_host_ssh', True)
+
+    # API token validation
+    if requires_api:
+        api_token = getattr(config, '_api_token', None) or getattr(config, 'api_token', None)
+        if callable(api_token):
+            api_token = api_token()
+        errors.extend(validate_api_token(
+            api_endpoint=config.api_endpoint,
+            api_token=api_token,
+            node_name=config.name
+        ))
+
+    # Host availability validation (skip if API validation already failed on connection)
+    if requires_host_ssh and not any("Cannot connect" in e for e in errors):
+        ssh_host = getattr(config, 'ssh_host', None) or getattr(config, 'ip', None)
+        errors.extend(validate_host_availability(
+            ssh_host=ssh_host,
+            node_name=config.name,
+            check_ssh=requires_host_ssh,
+            check_api=requires_api,
+            timeout=timeout
+        ))
+
+    return errors

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,222 @@
+"""Tests for validation module."""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+from src.validation import (
+    validate_api_token,
+    validate_host_resolvable,
+    validate_host_reachable,
+    validate_host_availability,
+    validate_readiness,
+)
+
+
+class TestValidateApiToken:
+    """Tests for API token validation."""
+
+    def test_missing_endpoint_returns_error(self):
+        """Missing API endpoint returns error."""
+        errors = validate_api_token(None, "token", "test")
+        assert len(errors) == 1
+        assert "API endpoint not configured" in errors[0]
+
+    def test_empty_endpoint_returns_error(self):
+        """Empty API endpoint returns error."""
+        errors = validate_api_token("", "token", "test")
+        assert len(errors) == 1
+        assert "API endpoint not configured" in errors[0]
+
+    def test_missing_token_returns_error(self):
+        """Missing API token returns error with decrypt instructions."""
+        errors = validate_api_token("https://localhost:8006", None, "test")
+        assert len(errors) == 1
+        assert "API token not found" in errors[0]
+        assert "make decrypt" in errors[0]
+
+    def test_empty_token_returns_error(self):
+        """Empty API token returns error."""
+        errors = validate_api_token("https://localhost:8006", "", "test")
+        assert len(errors) == 1
+        assert "API token not found" in errors[0]
+
+    def test_invalid_format_missing_exclamation_returns_error(self):
+        """Token without '!' returns format error."""
+        errors = validate_api_token("https://localhost:8006", "bad-token", "test")
+        assert len(errors) == 1
+        assert "invalid format" in errors[0]
+
+    def test_invalid_format_missing_equals_returns_error(self):
+        """Token without '=' returns format error."""
+        errors = validate_api_token("https://localhost:8006", "root@pam!token", "test")
+        assert len(errors) == 1
+        assert "invalid format" in errors[0]
+
+    @patch('src.validation.requests.get')
+    def test_401_returns_regenerate_instructions(self, mock_get):
+        """401 response returns regeneration instructions."""
+        mock_get.return_value.status_code = 401
+        errors = validate_api_token(
+            "https://localhost:8006",
+            "root@pam!test=abc123",
+            "test"
+        )
+        assert len(errors) == 1
+        assert "API token invalid" in errors[0]
+        assert "pveum user token add" in errors[0]
+
+    @patch('src.validation.requests.get')
+    def test_valid_token_returns_empty(self, mock_get):
+        """Valid token returns empty error list."""
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.json.return_value = {"data": {"version": "8.1"}}
+        errors = validate_api_token(
+            "https://localhost:8006",
+            "root@pam!test=abc123",
+            "test"
+        )
+        assert errors == []
+
+    @patch('src.validation.requests.get')
+    def test_unexpected_status_returns_error(self, mock_get):
+        """Unexpected status code returns error."""
+        mock_get.return_value.status_code = 500
+        mock_get.return_value.text = "Internal Server Error"
+        errors = validate_api_token(
+            "https://localhost:8006",
+            "root@pam!test=abc123",
+            "test"
+        )
+        assert len(errors) == 1
+        assert "Unexpected API response" in errors[0]
+        assert "500" in errors[0]
+
+    @patch('src.validation.requests.get')
+    def test_connection_error_returns_error(self, mock_get):
+        """Connection error returns descriptive error."""
+        import requests
+        mock_get.side_effect = requests.exceptions.ConnectionError("refused")
+        errors = validate_api_token(
+            "https://badhost:8006",
+            "root@pam!test=abc123",
+            "test"
+        )
+        assert len(errors) == 1
+        assert "Cannot connect" in errors[0]
+
+    @patch('src.validation.requests.get')
+    def test_timeout_returns_error(self, mock_get):
+        """Timeout returns descriptive error."""
+        import requests
+        mock_get.side_effect = requests.exceptions.Timeout()
+        errors = validate_api_token(
+            "https://slowhost:8006",
+            "root@pam!test=abc123",
+            "test"
+        )
+        assert len(errors) == 1
+        assert "Timeout" in errors[0]
+
+
+class TestValidateHostResolvable:
+    """Tests for hostname resolution validation."""
+
+    def test_localhost_resolves(self):
+        """localhost resolves to 127.0.0.1."""
+        success, result = validate_host_resolvable("localhost")
+        assert success is True
+        assert result == "127.0.0.1"
+
+    def test_ip_resolves_to_itself(self):
+        """IP address resolves to itself."""
+        success, result = validate_host_resolvable("127.0.0.1")
+        assert success is True
+        assert result == "127.0.0.1"
+
+    def test_invalid_hostname_fails(self):
+        """Non-existent hostname fails."""
+        success, result = validate_host_resolvable("nonexistent.invalid.test")
+        assert success is False
+        assert "Cannot resolve" in result
+
+
+class TestValidateHostReachable:
+    """Tests for host reachability validation."""
+
+    def test_unreachable_port_fails(self):
+        """Unreachable port returns failure."""
+        success, message = validate_host_reachable("127.0.0.1", port=59999, timeout=1)
+        assert success is False
+        assert "Cannot connect" in message
+
+    def test_timeout_returns_failure(self):
+        """Timeout returns failure with message."""
+        # Use a non-routable IP to trigger timeout
+        success, message = validate_host_reachable("10.255.255.1", port=22, timeout=0.5)
+        assert success is False
+        # Could be timeout or connection refused depending on network
+
+
+class TestValidateHostAvailability:
+    """Tests for combined host availability validation."""
+
+    def test_missing_host_returns_error(self):
+        """Missing SSH host returns error."""
+        errors = validate_host_availability(None, "test")
+        assert len(errors) == 1
+        assert "SSH host not configured" in errors[0]
+
+    def test_empty_host_returns_error(self):
+        """Empty SSH host returns error."""
+        errors = validate_host_availability("", "test")
+        assert len(errors) == 1
+        assert "SSH host not configured" in errors[0]
+
+    def test_unresolvable_host_returns_error(self):
+        """Unresolvable hostname returns error."""
+        errors = validate_host_availability("nonexistent.invalid.test", "test")
+        assert len(errors) == 1
+        assert "Cannot resolve" in errors[0]
+
+    def test_localhost_with_no_checks_passes(self):
+        """localhost with no port checks passes."""
+        errors = validate_host_availability(
+            "localhost", "test",
+            check_ssh=False, check_api=False
+        )
+        assert errors == []
+
+
+class TestValidateReadiness:
+    """Tests for combined readiness validation."""
+
+    def test_scenario_without_api_skips_token_check(self):
+        """Scenario with requires_api=False skips token validation."""
+        config = MagicMock()
+        config.name = "test"
+        config.api_endpoint = None  # Would fail if checked
+        config.ssh_host = "localhost"
+
+        class NoApiScenario:
+            requires_api = False
+            requires_host_ssh = False
+
+        errors = validate_readiness(config, NoApiScenario)
+        # Should not fail on missing API endpoint
+        assert not any("API endpoint" in e for e in errors)
+
+    def test_scenario_without_ssh_skips_host_check(self):
+        """Scenario with requires_host_ssh=False skips SSH check."""
+        config = MagicMock()
+        config.name = "test"
+        config.api_endpoint = "https://localhost:8006"
+        config._api_token = "root@pam!test=abc"
+        config.ssh_host = None  # Would fail if checked
+
+        class NoSshScenario:
+            requires_api = False
+            requires_host_ssh = False
+
+        errors = validate_readiness(config, NoSshScenario)
+        # Should not fail on missing SSH host
+        assert not any("SSH host" in e for e in errors)


### PR DESCRIPTION
## Summary
- Add validation.py module with API token and host availability checks
- Add create_local_config() for enhanced --local flag with auto-derived values
- Integrate pre-flight validation in CLI (skipped for --local and --dry-run)

## Changes

### New Files
- `src/validation.py` - Pre-flight validation module
- `tests/test_validation.py` - 22 unit tests for validation
- `tests/test_cli.py` - 7 unit tests for create_local_config()

### Modified Files
- `src/cli.py` - Integration of validation and local config

## Test plan
- [x] All 121 tests pass
- [ ] Manual test: `./run.sh --scenario vm-roundtrip --host father` (with valid token)
- [ ] Manual test: `./run.sh --scenario vm-roundtrip --host father` (with invalid token)
- [ ] Manual test: `./run.sh --scenario pve-setup --local` (auto-derives config)

## Issues
Closes #31 - Add API token validation as readiness check
Closes #32 - Add host availability readiness check
Closes #26 - Evaluate localhost host/node configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)