### PR TITLE
feat(cli): Add standard flags and git-derived versions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -570,6 +570,7 @@ The orchestrator runs scenarios composed of reusable actions:
 **CLI Options:**
 | Option | Description |
 |--------|-------------|
+| `--version` | Show CLI version |
 | `--scenario`, `-S` | Scenario to run (required) |
 | `--host`, `-H` | Target PVE host (required for most scenarios) |
 | `--env`, `-E` | Environment to deploy (overrides scenario default) |
@@ -676,7 +677,9 @@ Both JSON and markdown reports are generated for each run.
 | Script | Purpose |
 |--------|---------|
 | `scripts/wait-for-guest-agent.sh` | Poll for VM IP (used by orchestrator) |
-| `scripts/setup-tools.sh` | Clone/update tool repos |
+| `scripts/setup-tools.sh` | Clone/update tool repos (ansible, tofu, packer, site-config) |
+
+All helper scripts support `--help` for usage information.
 
 ### Tofu Environments
 

--- a/scripts/setup-tools.sh
+++ b/scripts/setup-tools.sh
@@ -1,20 +1,57 @@
 #!/bin/bash
 # Setup or update tool repositories
-# Usage: setup-tools.sh [base_dir]
+# Usage: setup-tools.sh [options] [base_dir]
 #
-# Clones ansible, tofu, and packer repos if they don't exist,
+# Clones ansible, tofu, packer, and site-config repos if they don't exist,
 # or pulls latest changes if they do.
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GITHUB_ORG="homestak-dev"
+
+show_help() {
+    cat << 'EOF'
+setup-tools.sh - Setup or update tool repositories
+
+Usage:
+  setup-tools.sh [options] [base_dir]
+
+Options:
+  --help, -h    Show this help message
+
+Arguments:
+  base_dir      Base directory for repos (default: parent of iac-driver)
+
+Description:
+  Clones ansible, tofu, packer, and site-config repos as siblings to iac-driver.
+  If repos already exist, pulls latest changes instead.
+
+Repositories:
+  - ansible        Playbooks and roles
+  - tofu           VM provisioning
+  - packer         Cloud image building
+  - site-config    Configuration and secrets
+
+Examples:
+  ./setup-tools.sh                    # Use default base directory
+  ./setup-tools.sh /opt/homestak      # Specify custom base directory
+EOF
+    exit 0
+}
+
+# Parse arguments
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+    show_help
+fi
+
 BASE_DIR="${1:-$(dirname "$(dirname "$SCRIPT_DIR")")}"
-GITHUB_USER="john-derose"
 
 declare -A REPOS=(
-  [ansible]="https://github.com/$GITHUB_USER/ansible.git"
-  [tofu]="https://github.com/$GITHUB_USER/tofu.git"
-  [packer]="https://github.com/$GITHUB_USER/packer.git"
+  [ansible]="https://github.com/$GITHUB_ORG/ansible.git"
+  [tofu]="https://github.com/$GITHUB_ORG/tofu.git"
+  [packer]="https://github.com/$GITHUB_ORG/packer.git"
+  [site-config]="https://github.com/$GITHUB_ORG/site-config.git"
 )
 
 echo "Setting up tool repositories in: $BASE_DIR"

--- a/scripts/wait-for-guest-agent.sh
+++ b/scripts/wait-for-guest-agent.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Wait for QEMU guest agent to report an IP address
-# Usage: wait-for-guest-agent.sh <vmid> [interface] [timeout_seconds]
+# Usage: wait-for-guest-agent.sh [options] <vmid> [interface] [timeout_seconds]
 #
 # Examples:
 #   ./wait-for-guest-agent.sh 99913              # Wait for eth0 IP, 120s timeout
@@ -8,6 +8,45 @@
 #   ./wait-for-guest-agent.sh 99913 eth0 60      # 60 second timeout
 
 set -euo pipefail
+
+show_help() {
+    cat << 'EOF'
+wait-for-guest-agent.sh - Wait for QEMU guest agent to report an IP address
+
+Usage:
+  wait-for-guest-agent.sh [options] <vmid> [interface] [timeout_seconds]
+
+Options:
+  --help, -h    Show this help message
+
+Arguments:
+  vmid          VM ID to query (required)
+  interface     Network interface to check (default: eth0)
+  timeout       Timeout in seconds (default: 120)
+
+Description:
+  Polls the QEMU guest agent on the specified VM until it reports an IPv4
+  address for the given interface, or until timeout is reached.
+
+  On success, prints the IP address to stdout and exits 0.
+  On timeout, prints error to stderr and exits 1.
+
+Examples:
+  ./wait-for-guest-agent.sh 99913              # Wait for eth0 IP, 120s timeout
+  ./wait-for-guest-agent.sh 99913 vmbr0        # Wait for vmbr0 IP
+  ./wait-for-guest-agent.sh 99913 eth0 60      # 60 second timeout
+
+Dependencies:
+  - qm (Proxmox VE command)
+  - jq (JSON processor)
+EOF
+    exit 0
+}
+
+# Parse arguments
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+    show_help
+fi
 
 VMID="${1:?Usage: $0 <vmid> [interface] [timeout_seconds]}"
 IFACE="${2:-eth0}"

--- a/src/cli.py
+++ b/src/cli.py
@@ -6,12 +6,26 @@ import json
 import logging
 import os
 import socket
+import subprocess
 import sys
 from pathlib import Path
 
 from config import list_hosts, list_envs, load_host_config, get_base_dir
 from scenarios import Orchestrator, get_scenario, list_scenarios
 from validation import validate_readiness, run_preflight_checks, format_preflight_results
+
+
+def get_version():
+    """Get version from git tags (do not use hardcoded VERSION constant)."""
+    try:
+        result = subprocess.run(
+            ['git', 'describe', '--tags', '--abbrev=0'],
+            capture_output=True, text=True,
+            cwd=Path(__file__).parent
+        )
+        return result.stdout.strip() if result.returncode == 0 else 'dev'
+    except Exception:
+        return 'dev'
 
 # Configure logging
 logging.basicConfig(
@@ -67,6 +81,11 @@ def main():
 
     parser = argparse.ArgumentParser(
         description='Infrastructure-as-Code Driver - Orchestrates provisioning and testing workflows'
+    )
+    parser.add_argument(
+        '--version',
+        action='version',
+        version=f'iac-driver {get_version()}'
     )
     parser.add_argument(
         '--scenario', '-S',


### PR DESCRIPTION
## Summary

- Add `--version` to `run.sh` (cli.py) with git-derived version
- Add `--help` to `setup-tools.sh` and `wait-for-guest-agent.sh`
- Fix GitHub org bug in `setup-tools.sh` (was `john-derose`, now `homestak-dev`)
- Add `site-config` to `setup-tools.sh` repo list
- Update `CLAUDE.md` documentation

## Git-Derived Version Pattern (Python)

```python
def get_version():
    try:
        result = subprocess.run(
            ['git', 'describe', '--tags', '--abbrev=0'],
            capture_output=True, text=True,
            cwd=Path(__file__).parent
        )
        return result.stdout.strip() if result.returncode == 0 else 'dev'
    except Exception:
        return 'dev'
```

## Bug Fix

`setup-tools.sh` had a hardcoded GitHub user (`john-derose`) instead of the organization (`homestak-dev`). This is now fixed.

## Test plan

- [x] `./run.sh --version` outputs `iac-driver v0.31`
- [x] `./scripts/setup-tools.sh --help` shows help text
- [x] `./scripts/wait-for-guest-agent.sh --help` shows help text
- [x] Python syntax validation passes
- [x] Bash syntax validation passes

## Related Issues

- Part of homestak-dev#116 (CLI standardization epic)
- Closes #102 (--version for run.sh, --help for helpers, fix bug)

🤖 Generated with [Claude Code](https://claude.ai/code)