### PR TITLE
Add --json-output flag for structured scenario results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Added
+- Add `--json-output` flag for structured scenario results (#109)
+  - JSON output to stdout, logs to stderr
+  - Includes scenario name, success status, duration, phase results
+  - Context values (vm_ip, vm_id, etc.) included for parent consumption
+  - Error details included on failure
+
 ## v0.37 - 2026-01-20
 
 ### Theme: Foundation for Recursion

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -614,6 +614,41 @@ The orchestrator runs scenarios composed of reusable actions:
 | `--dry-run` | Preview scenario phases without executing actions |
 | `--preflight` | Run preflight checks only (no scenario execution) |
 | `--skip-preflight` | Skip preflight checks before scenario execution |
+| `--json-output` | Output structured JSON to stdout (logs to stderr) |
+
+**JSON Output (v0.38+):**
+
+The `--json-output` flag emits structured JSON for programmatic consumption:
+
+```bash
+./run.sh --scenario vm-roundtrip --host father --json-output 2>/dev/null | jq .
+```
+
+Output schema:
+```json
+{
+  "scenario": "vm-roundtrip",
+  "success": true,
+  "duration_seconds": 45.2,
+  "phases": [
+    {"name": "ensure_image", "status": "passed", "duration": 0.2},
+    {"name": "provision", "status": "passed", "duration": 6.8}
+  ],
+  "context": {
+    "vm_ip": "10.0.12.155",
+    "vm_id": 99900
+  }
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `scenario` | Scenario name |
+| `success` | Boolean result |
+| `duration_seconds` | Total runtime |
+| `phases[]` | Phase results (name, status, duration) |
+| `context` | Collected values (IPs, IDs, etc.) |
+| `error` | Error message (on failure only) |
 
 **Preflight Checks:**
 


### PR DESCRIPTION
## Summary
- Add `--json-output` flag to CLI for structured JSON output
- JSON emitted to stdout at scenario completion
- Logs redirected to stderr when JSON enabled
- Context values (vm_ip, vm_id, etc.) included for parent consumption
- Error details included on failure

## JSON Schema
```json
{
  "scenario": "vm-roundtrip",
  "success": true,
  "duration_seconds": 45.2,
  "phases": [
    {"name": "ensure_image", "status": "passed", "duration": 0.2}
  ],
  "context": {"vm_ip": "10.0.12.155", "vm_id": 99900}
}
```

## Test plan
- [x] `make test` passes (165/165 tests)
- [x] `--json-output` appears in `--help`
- [x] Python syntax validated

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)