### PR TITLE
feat(scenarios): Add recursive-pve scenarios with manifest-driven depth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,59 @@
 
 ## Unreleased
 
+### Added
+- Add `RecursiveScenarioAction` for SSH-streamed scenario execution (#104)
+  - PTY allocation for real-time output streaming
+  - JSON result parsing from `--json-output` scenarios
+  - Context key extraction for parent scenario consumption
+  - Configurable timeout and SSH user
+
+- Add manifest-driven recursive scenarios (#114)
+  - `manifest.py` with `Manifest`, `ManifestLevel`, `ManifestSettings` dataclasses
+  - `ManifestLoader` for YAML file loading from site-config/manifests/
+  - Schema versioning (v1 = linear levels array)
+  - Depth limiting via `--depth` flag
+  - JSON serialization for recursive calls via `--manifest-json`
+
+- Add recursive-pve scenarios for N-level nested PVE (#114)
+  - `recursive-pve-constructor`: Build N-level stack per manifest
+  - `recursive-pve-destructor`: Tear down stack in reverse order
+  - `recursive-pve-roundtrip`: Constructor + destructor full cycle
+  - Helper actions: `BootstrapAction`, `CopySecretsAction`, `GenerateNodeConfigAction`
+
+- Add CLI flags for manifest-driven scenarios
+  - `--manifest`, `-M`: Manifest name from site-config/manifests/
+  - `--manifest-file`: Path to manifest file
+  - `--manifest-json`: Inline manifest JSON (for recursive calls)
+  - `--keep-on-failure`: Keep levels on failure for debugging
+  - `--depth`: Limit manifest to first N levels
+
+- Add raw file serving to serve-repos.sh for fully offline bootstrap (#119)
+  - `serve_raw_file()` extracts files from bare repos via `git show`
+  - BootstrapAction fetches `{source_url}/bootstrap.git/install.sh` when HOMESTAK_SOURCE set
+  - Enables recursive scenarios without GitHub connectivity
+
+### Fixed
+- Fix `BootstrapAction` to integrate with serve-repos env vars (#116)
+  - Reads `HOMESTAK_SOURCE`, `HOMESTAK_TOKEN`, `HOMESTAK_REF` from environment
+  - Builds bootstrap command with proper env var prefix for dev workflow
+  - Falls back to GitHub URL when serve-repos not configured
+
+- Fix `timeout_buffer` manifest setting not applied to recursive timeouts (#117)
+  - Add `_get_recursive_timeout()` method to `RecursivePVEBase`
+  - Subtracts `timeout_buffer` from base timeout to ensure cleanup time
+  - Applies to all `RecursiveScenarioAction` invocations
+
+- Fix `cleanup_on_failure` manifest setting not propagated (#118)
+  - Add `_get_effective_keep_on_failure()` method to `RecursivePVEBase`
+  - CLI `--keep-on-failure` takes precedence over manifest setting
+  - Manifest `cleanup_on_failure: false` maps to `keep_on_failure: true`
+  - Setting propagated to recursive constructor calls
+
+### Testing
+- Add unit tests for RecursiveScenarioAction (27 tests)
+- Add unit tests for manifest loading and validation (29 tests)
+
 ## v0.38 - 2026-01-21
 
 ### Added

--- a/run.sh
+++ b/run.sh
@@ -113,7 +113,12 @@ stop_serve_repos() {
 if [[ "$SERVE_REPOS" == true ]]; then
     start_serve_repos || exit 1
     trap stop_serve_repos EXIT INT TERM
+    # Don't use exec - we need bash process to stay alive for trap handler
+    python3 "$SCRIPT_DIR/src/cli.py" "${CLI_ARGS[@]}"
+    exit_code=$?
+    stop_serve_repos
+    exit $exit_code
+else
+    # No serve-repos, safe to exec
+    exec python3 "$SCRIPT_DIR/src/cli.py" "${CLI_ARGS[@]}"
 fi
-
-# Pass remaining arguments to Python CLI
-exec python3 "$SCRIPT_DIR/src/cli.py" "${CLI_ARGS[@]}"

--- a/src/actions/__init__.py
+++ b/src/actions/__init__.py
@@ -12,6 +12,7 @@ from actions.proxmox import (
     WaitForGuestAgentRemoteAction,
 )
 from actions.file import RemoveImageAction, DownloadFileAction, DownloadGitHubReleaseAction
+from actions.recursive import RecursiveScenarioAction
 
 __all__ = [
     'TofuApplyAction',
@@ -34,4 +35,5 @@ __all__ = [
     'RemoveImageAction',
     'DownloadFileAction',
     'DownloadGitHubReleaseAction',
+    'RecursiveScenarioAction',
 ]

--- a/src/actions/file.py
+++ b/src/actions/file.py
@@ -154,10 +154,11 @@ class DownloadGitHubReleaseAction:
 
         GitHub download URLs require the actual tag name, not 'latest'.
         This queries the API to get the real tag for the latest release.
+        Uses Python for JSON parsing (available on all PVE hosts) instead of jq.
         """
         api_url = f'https://api.github.com/repos/{repo}/releases/latest'
-        # Use curl with jq to extract tag_name
-        cmd = f"curl -fsSL '{api_url}' | jq -r '.tag_name'"
+        # Use curl with Python to extract tag_name (Python is always available on PVE)
+        cmd = f"curl -fsSL '{api_url}' | python3 -c \"import sys,json; print(json.load(sys.stdin).get('tag_name',''))\""
         rc, out, err = run_ssh(host, cmd, timeout=30)
         if rc == 0 and out.strip():
             return out.strip()

--- a/src/actions/recursive.py
+++ b/src/actions/recursive.py
@@ -1,0 +1,375 @@
+"""Recursive scenario execution actions.
+
+Enables running scenarios on remote bootstrapped hosts via SSH with real-time streaming.
+"""
+
+import json
+import logging
+import re
+import select
+import shlex
+import subprocess
+import time
+from dataclasses import dataclass, field
+from typing import Optional
+
+from common import ActionResult
+from config import HostConfig
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class RecursiveScenarioAction:
+    """Execute a scenario on a remote bootstrapped host via SSH with real-time streaming.
+
+    This action SSHs to a target host that has been bootstrapped with the homestak CLI,
+    runs a scenario using 'homestak scenario <name> --json-output', streams the output
+    in real-time, and parses the JSON result at completion.
+
+    The target host must have:
+    - homestak CLI installed at /usr/local/bin/homestak
+    - Valid site-config at /usr/local/etc/homestak/
+    - Decrypted secrets
+
+    Attributes:
+        name: Action identifier for logging/reporting
+        scenario_name: Scenario to execute (e.g., 'vm-roundtrip')
+        host_attr: Context key containing target host IP (default: 'inner_ip')
+        timeout: Overall timeout in seconds (default: 600)
+        scenario_args: Additional CLI arguments to pass (e.g., ['--host', 'nested-pve'])
+        context_keys: Keys to extract from JSON result into context_updates
+        use_pty: Whether to use PTY allocation for real-time streaming (default: True)
+        ssh_user: SSH username (default: 'root')
+    """
+    name: str
+    scenario_name: str
+    host_attr: str = 'inner_ip'
+    timeout: int = 600
+    scenario_args: list[str] = field(default_factory=list)
+    context_keys: list[str] = field(default_factory=list)
+    use_pty: bool = True
+    ssh_user: str = 'root'
+
+    def run(self, config: HostConfig, context: dict) -> ActionResult:
+        """Execute scenario via SSH with streaming output.
+
+        1. SSH to target host with optional PTY allocation
+        2. Run: homestak scenario <name> --json-output [args...]
+        3. Stream stdout/stderr to logger in real-time with [inner] prefix
+        4. Parse final JSON result from stdout
+        5. Extract context_keys from result into context_updates
+
+        Returns:
+            ActionResult with success status, message, duration, and context_updates
+        """
+        start = time.time()
+
+        # Get target host from context
+        host = context.get(self.host_attr)
+        if not host:
+            return ActionResult(
+                success=False,
+                message=f"No {self.host_attr} in context",
+                duration=time.time() - start
+            )
+
+        # Build the remote command
+        remote_cmd = self._build_remote_command()
+
+        logger.info(f"[{self.name}] Starting {self.scenario_name} on {host}")
+        logger.debug(f"[{self.name}] Command: {remote_cmd}")
+
+        try:
+            if self.use_pty:
+                result = self._run_with_pty(host, remote_cmd)
+            else:
+                result = self._run_without_pty(host, remote_cmd)
+
+            rc, output, stderr = result
+
+            # Parse JSON result from output
+            json_result = self._parse_json_result(output)
+
+            if rc != 0:
+                error_msg = self._extract_error_message(json_result, stderr, output)
+                return ActionResult(
+                    success=False,
+                    message=f"Scenario {self.scenario_name} failed: {error_msg}",
+                    duration=time.time() - start
+                )
+
+            # Extract context keys
+            context_updates = self._extract_context(json_result)
+
+            # Get duration from inner scenario if available
+            inner_duration = json_result.get('duration_seconds', 0) if json_result else 0
+
+            return ActionResult(
+                success=True,
+                message=f"Scenario {self.scenario_name} completed ({inner_duration}s)",
+                duration=time.time() - start,
+                context_updates=context_updates
+            )
+
+        except subprocess.TimeoutExpired:
+            return ActionResult(
+                success=False,
+                message=f"Timeout ({self.timeout}s) waiting for {self.scenario_name}",
+                duration=time.time() - start
+            )
+        except Exception as e:
+            return ActionResult(
+                success=False,
+                message=f"Error executing {self.scenario_name}: {e}",
+                duration=time.time() - start
+            )
+
+    def _build_remote_command(self) -> str:
+        """Build the homestak command to run on the remote host.
+
+        All arguments are shell-quoted to handle JSON and other special characters
+        that may be passed via scenario_args.
+        """
+        cmd_parts = [
+            'homestak', 'scenario', self.scenario_name,
+            '--json-output'
+        ]
+        cmd_parts.extend(self.scenario_args)
+        # Quote each part to handle special characters (especially JSON with spaces)
+        return ' '.join(shlex.quote(p) for p in cmd_parts)
+
+    def _build_ssh_command(self, host: str, remote_cmd: str) -> list[str]:
+        """Build SSH command with appropriate options."""
+        ssh_opts = [
+            '-o', 'StrictHostKeyChecking=no',
+            '-o', 'UserKnownHostsFile=/dev/null',
+            '-o', 'LogLevel=ERROR',
+            '-o', f'ConnectTimeout=30',
+        ]
+
+        if self.use_pty:
+            ssh_opts.append('-t')  # Force PTY allocation for streaming
+
+        return [
+            'ssh',
+            *ssh_opts,
+            f'{self.ssh_user}@{host}',
+            remote_cmd
+        ]
+
+    def _run_with_pty(self, host: str, remote_cmd: str) -> tuple[int, str, str]:
+        """Execute SSH command with PTY for real-time streaming.
+
+        Uses subprocess with line-by-line reading to stream output as it arrives.
+        Output is logged with [inner] prefix for visibility.
+        """
+        cmd = self._build_ssh_command(host, remote_cmd)
+
+        # Use unbuffered output for real-time streaming
+        process = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            bufsize=1,  # Line buffered
+        )
+
+        output_lines = []
+        stderr_lines = []
+        deadline = time.time() + self.timeout
+
+        try:
+            # Read output line by line with timeout checking
+            while True:
+                # Check timeout
+                if time.time() > deadline:
+                    process.kill()
+                    raise subprocess.TimeoutExpired(cmd, self.timeout)
+
+                # Check if process finished
+                if process.poll() is not None:
+                    # Read any remaining output
+                    remaining_out, remaining_err = process.communicate(timeout=5)
+                    if remaining_out:
+                        for line in remaining_out.splitlines():
+                            self._log_inner_line(line)
+                            output_lines.append(line)
+                    if remaining_err:
+                        stderr_lines.extend(remaining_err.splitlines())
+                    break
+
+                # Use select for non-blocking read with timeout
+                readable, _, _ = select.select(
+                    [process.stdout, process.stderr],
+                    [], [],
+                    1.0  # 1 second timeout for select
+                )
+
+                for stream in readable:
+                    line = stream.readline()
+                    if line:
+                        line = line.rstrip('\n')
+                        if stream == process.stdout:
+                            self._log_inner_line(line)
+                            output_lines.append(line)
+                        else:
+                            stderr_lines.append(line)
+
+            rc = process.returncode
+
+        except Exception:
+            process.kill()
+            raise
+
+        return rc, '\n'.join(output_lines), '\n'.join(stderr_lines)
+
+    def _run_without_pty(self, host: str, remote_cmd: str) -> tuple[int, str, str]:
+        """Execute SSH command without PTY (fallback mode)."""
+        cmd = self._build_ssh_command(host, remote_cmd)
+        # Remove -t flag if present
+        if '-t' in cmd:
+            cmd.remove('-t')
+
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=self.timeout
+        )
+
+        # Log output after completion (no streaming)
+        for line in result.stdout.splitlines():
+            self._log_inner_line(line)
+
+        return result.returncode, result.stdout, result.stderr
+
+    def _log_inner_line(self, line: str):
+        """Log a line from the inner scenario with [inner] prefix.
+
+        JSON output is logged at debug level, phase progress at info level.
+        """
+        # Skip empty lines
+        if not line.strip():
+            return
+
+        # Detect JSON (final output)
+        if line.strip().startswith('{') or line.strip().startswith('['):
+            logger.debug(f"[inner] {line}")
+            return
+
+        # Log phase progress and other output at info level
+        logger.info(f"[inner] {line}")
+
+    def _parse_json_result(self, output: str) -> Optional[dict]:
+        """Parse JSON result from scenario output.
+
+        The JSON is expected to be at the end of the output, possibly after
+        log messages. We search for the last valid JSON object.
+        """
+        if not output:
+            return None
+
+        # First, try the entire output as JSON (if it's just JSON)
+        try:
+            return json.loads(output.strip())
+        except json.JSONDecodeError:
+            pass
+
+        # Look for JSON starting from the end of output
+        # Try each line from the end to find JSON
+        lines = output.strip().split('\n')
+
+        # Strategy 1: Try each line from the end as potential single-line JSON
+        for line in reversed(lines):
+            stripped = line.strip()
+            if stripped.startswith('{') and stripped.endswith('}'):
+                try:
+                    return json.loads(stripped)
+                except json.JSONDecodeError:
+                    continue
+
+        # Strategy 2: Look for multi-line JSON block
+        json_lines = []
+        brace_count = 0
+        in_json = False
+
+        for line in reversed(lines):
+            stripped = line.strip()
+
+            if not in_json:
+                if stripped.endswith('}'):
+                    in_json = True
+                    brace_count = stripped.count('}') - stripped.count('{')
+                    json_lines.insert(0, line)
+                    # Check if this single line is complete JSON
+                    if brace_count == 0 and stripped.startswith('{'):
+                        try:
+                            return json.loads(stripped)
+                        except json.JSONDecodeError:
+                            pass
+            else:
+                json_lines.insert(0, line)
+                brace_count += stripped.count('}') - stripped.count('{')
+
+                if brace_count <= 0 and stripped.startswith('{'):
+                    break
+
+        if json_lines:
+            json_str = '\n'.join(json_lines)
+            try:
+                return json.loads(json_str)
+            except json.JSONDecodeError:
+                logger.debug(f"Failed to parse JSON: {json_str[:200]}")
+
+        return None
+
+    def _extract_error_message(
+        self,
+        json_result: Optional[dict],
+        stderr: str,
+        stdout: str
+    ) -> str:
+        """Extract a meaningful error message from available output."""
+        # First priority: error from JSON result
+        if json_result and 'error' in json_result:
+            return json_result['error']
+
+        # Second: look for failed phase in JSON
+        if json_result and 'phases' in json_result:
+            for phase in json_result['phases']:
+                if phase.get('status') == 'failed':
+                    return f"Phase '{phase['name']}' failed"
+
+        # Third: stderr content
+        if stderr and stderr.strip():
+            # Return last non-empty line of stderr
+            lines = [l for l in stderr.strip().split('\n') if l.strip()]
+            if lines:
+                return lines[-1][:200]
+
+        # Fourth: look for error patterns in stdout
+        for line in reversed(stdout.split('\n')):
+            if 'error' in line.lower() or 'failed' in line.lower():
+                return line.strip()[:200]
+
+        return "Unknown error (no details available)"
+
+    def _extract_context(self, json_result: Optional[dict]) -> dict:
+        """Extract specified context keys from JSON result."""
+        context_updates = {}
+
+        if not json_result:
+            return context_updates
+
+        # Extract from context field if present
+        result_context = json_result.get('context', {})
+
+        for key in self.context_keys:
+            if key in result_context:
+                context_updates[key] = result_context[key]
+                logger.debug(f"Extracted context key '{key}': {result_context[key]}")
+            else:
+                logger.debug(f"Context key '{key}' not found in result")
+
+        return context_updates

--- a/src/config_resolver.py
+++ b/src/config_resolver.py
@@ -115,11 +115,21 @@ class ConfigResolver:
         ssh_keys_dict = self.secrets.get("ssh_keys", {})
         ssh_keys_list = list(ssh_keys_dict.values())
 
+        # Determine SSH host for file uploads
+        # If api_endpoint is localhost, use 127.0.0.1 for SSH
+        # Otherwise use explicit ip from node config
+        api_endpoint = node_config.get("api_endpoint", "")
+        if "localhost" in api_endpoint or "127.0.0.1" in api_endpoint:
+            ssh_host = "127.0.0.1"
+        else:
+            ssh_host = node_config.get("ip", "")
+
         return {
             "node": node_config.get("node", node),
-            "api_endpoint": node_config.get("api_endpoint", ""),
+            "api_endpoint": api_endpoint,
             "api_token": api_token,
             "ssh_user": defaults.get("ssh_user", "root"),
+            "ssh_host": ssh_host,  # For proxmox provider SSH file uploads
             "datastore": node_config["datastore"],  # Required from node config (v0.13+)
             "root_password": passwords.get("vm_root", ""),
             "ssh_keys": ssh_keys_list,

--- a/src/manifest.py
+++ b/src/manifest.py
@@ -1,0 +1,383 @@
+"""Manifest loading and validation for recursive PVE scenarios.
+
+Manifests define recursion levels for multi-level nested PVE deployments.
+They reference existing site-config entities (envs, vms) via foreign keys.
+
+Schema v1: Linear levels array (v0.39+)
+Schema v2: Tree structure with parent references (future, #115)
+"""
+
+import json
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+try:
+    import yaml
+except ImportError:
+    yaml = None  # type: ignore[assignment]
+
+from config import ConfigError, get_site_config_dir
+
+logger = logging.getLogger(__name__)
+
+# Default manifest name when none specified
+DEFAULT_MANIFEST = 'n2-quick'
+
+# Supported schema versions
+SUPPORTED_SCHEMA_VERSIONS = {1}
+
+
+@dataclass
+class ManifestLevel:
+    """A single level in the recursion manifest.
+
+    Attributes:
+        name: Level identifier (used in context keys, e.g., 'inner-pve')
+        env: FK to site-config/envs/*.yaml
+        image: Optional image override (FK to packer image)
+        vmid_offset: Optional offset from env's vmid_base
+        post_scenario: Optional scenario to run after bootstrap
+        post_scenario_args: Arguments for post_scenario
+    """
+    name: str
+    env: str
+    image: Optional[str] = None
+    vmid_offset: int = 0
+    post_scenario: Optional[str] = None
+    post_scenario_args: list[str] = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, data: dict) -> 'ManifestLevel':
+        """Create ManifestLevel from dictionary."""
+        return cls(
+            name=data['name'],
+            env=data['env'],
+            image=data.get('image'),
+            vmid_offset=data.get('vmid_offset', 0),
+            post_scenario=data.get('post_scenario'),
+            post_scenario_args=data.get('post_scenario_args', [])
+        )
+
+
+@dataclass
+class ManifestSettings:
+    """Optional settings for manifest execution.
+
+    Attributes:
+        verify_ssh: Verify SSH at each level (default: True)
+        cleanup_on_failure: Destroy levels on failure (default: True)
+        timeout_buffer: Seconds to subtract per level (default: 60)
+    """
+    verify_ssh: bool = True
+    cleanup_on_failure: bool = True
+    timeout_buffer: int = 60
+
+    @classmethod
+    def from_dict(cls, data: Optional[dict]) -> 'ManifestSettings':
+        """Create ManifestSettings from dictionary."""
+        if not data:
+            return cls()
+        return cls(
+            verify_ssh=data.get('verify_ssh', True),
+            cleanup_on_failure=data.get('cleanup_on_failure', True),
+            timeout_buffer=data.get('timeout_buffer', 60)
+        )
+
+
+@dataclass
+class Manifest:
+    """Recursion manifest for multi-level nested PVE.
+
+    Defines the levels of recursion for recursive-pve scenarios.
+    Each level references site-config entities (envs, vms) via FK.
+
+    Attributes:
+        schema_version: Manifest schema version (default: 1)
+        name: Human-readable manifest name
+        description: Optional description
+        levels: Ordered list of recursion levels (first = outermost)
+        settings: Optional execution settings
+        source_path: Path where manifest was loaded from (for debugging)
+    """
+    schema_version: int
+    name: str
+    levels: list[ManifestLevel]
+    description: str = ''
+    settings: ManifestSettings = field(default_factory=ManifestSettings)
+    source_path: Optional[Path] = None
+
+    @property
+    def depth(self) -> int:
+        """Number of recursion levels."""
+        return len(self.levels)
+
+    @property
+    def is_leaf(self) -> bool:
+        """True if this manifest has only one level (leaf node)."""
+        return len(self.levels) == 1
+
+    def get_current_level(self) -> ManifestLevel:
+        """Get the first (current) level."""
+        if not self.levels:
+            raise ConfigError("Manifest has no levels")
+        return self.levels[0]
+
+    def get_remaining_manifest(self) -> 'Manifest':
+        """Get manifest with levels[1:] for recursion.
+
+        Returns a new Manifest with the first level removed,
+        suitable for passing to inner recursive execution.
+        """
+        if len(self.levels) <= 1:
+            raise ConfigError("Cannot get remaining manifest: already at leaf level")
+
+        return Manifest(
+            schema_version=self.schema_version,
+            name=f"{self.name}[1:]",
+            description=self.description,
+            levels=[ManifestLevel.from_dict(vars(l)) for l in self.levels[1:]],
+            settings=ManifestSettings(
+                verify_ssh=self.settings.verify_ssh,
+                cleanup_on_failure=self.settings.cleanup_on_failure,
+                timeout_buffer=self.settings.timeout_buffer
+            ),
+            source_path=self.source_path
+        )
+
+    def to_dict(self) -> dict:
+        """Convert manifest to dictionary (for JSON serialization)."""
+        return {
+            'schema_version': self.schema_version,
+            'name': self.name,
+            'description': self.description,
+            'levels': [
+                {
+                    'name': level.name,
+                    'env': level.env,
+                    'image': level.image,
+                    'vmid_offset': level.vmid_offset,
+                    'post_scenario': level.post_scenario,
+                    'post_scenario_args': level.post_scenario_args
+                }
+                for level in self.levels
+            ],
+            'settings': {
+                'verify_ssh': self.settings.verify_ssh,
+                'cleanup_on_failure': self.settings.cleanup_on_failure,
+                'timeout_buffer': self.settings.timeout_buffer
+            }
+        }
+
+    def to_json(self) -> str:
+        """Serialize manifest to JSON string."""
+        return json.dumps(self.to_dict())
+
+    @classmethod
+    def from_dict(cls, data: dict, source_path: Optional[Path] = None) -> 'Manifest':
+        """Create Manifest from dictionary.
+
+        Args:
+            data: Manifest data dictionary
+            source_path: Optional source path for error messages
+
+        Returns:
+            Validated Manifest instance
+
+        Raises:
+            ConfigError: If manifest is invalid
+        """
+        # Validate schema version
+        schema_version = data.get('schema_version', 1)
+        if schema_version not in SUPPORTED_SCHEMA_VERSIONS:
+            raise ConfigError(
+                f"Unsupported manifest schema version: {schema_version}. "
+                f"Supported versions: {sorted(SUPPORTED_SCHEMA_VERSIONS)}"
+            )
+
+        # Validate required fields
+        if 'name' not in data:
+            raise ConfigError("Manifest missing required field: name")
+        if 'levels' not in data:
+            raise ConfigError("Manifest missing required field: levels")
+        if not data['levels']:
+            raise ConfigError("Manifest must have at least one level")
+
+        # Parse levels
+        levels = []
+        for i, level_data in enumerate(data['levels']):
+            if 'name' not in level_data:
+                raise ConfigError(f"Level {i} missing required field: name")
+            if 'env' not in level_data:
+                raise ConfigError(f"Level {i} ({level_data.get('name', 'unnamed')}) missing required field: env")
+            levels.append(ManifestLevel.from_dict(level_data))
+
+        return cls(
+            schema_version=schema_version,
+            name=data['name'],
+            description=data.get('description', ''),
+            levels=levels,
+            settings=ManifestSettings.from_dict(data.get('settings')),
+            source_path=source_path
+        )
+
+    @classmethod
+    def from_json(cls, json_str: str) -> 'Manifest':
+        """Create Manifest from JSON string."""
+        try:
+            data = json.loads(json_str)
+        except json.JSONDecodeError as e:
+            raise ConfigError(f"Invalid manifest JSON: {e}")
+        return cls.from_dict(data)
+
+
+class ManifestLoader:
+    """Loads manifests from site-config/manifests/ directory."""
+
+    def __init__(self, site_config_path: Optional[str] = None):
+        """Initialize loader with site-config path.
+
+        Args:
+            site_config_path: Path to site-config directory. If None, uses
+                              auto-discovery (env var, sibling, /opt/homestak).
+        """
+        if yaml is None:
+            raise ConfigError("PyYAML not installed. Run: apt install python3-yaml")
+
+        if site_config_path:
+            self.site_config_dir = Path(site_config_path)
+        else:
+            self.site_config_dir = get_site_config_dir()
+
+        self.manifests_dir = self.site_config_dir / 'manifests'
+
+    def list_manifests(self) -> list[str]:
+        """List available manifest names."""
+        if not self.manifests_dir.exists():
+            return []
+        return sorted([
+            f.stem for f in self.manifests_dir.glob('*.yaml')
+            if f.is_file()
+        ])
+
+    def load(self, name: str) -> Manifest:
+        """Load manifest by name.
+
+        Args:
+            name: Manifest name (without .yaml extension)
+
+        Returns:
+            Manifest instance
+
+        Raises:
+            ConfigError: If manifest not found or invalid
+        """
+        path = self.manifests_dir / f'{name}.yaml'
+        if not path.exists():
+            available = self.list_manifests()
+            raise ConfigError(
+                f"Manifest '{name}' not found at {path}. "
+                f"Available: {', '.join(available) if available else 'none'}"
+            )
+
+        return self.load_file(path)
+
+    def load_file(self, path: Path) -> Manifest:
+        """Load manifest from specific file path.
+
+        Args:
+            path: Path to manifest YAML file
+
+        Returns:
+            Manifest instance
+
+        Raises:
+            ConfigError: If file not found or invalid
+        """
+        if not path.exists():
+            raise ConfigError(f"Manifest file not found: {path}")
+
+        try:
+            with open(path, encoding='utf-8') as f:
+                data = yaml.safe_load(f)
+        except yaml.YAMLError as e:
+            raise ConfigError(f"Invalid YAML in manifest {path}: {e}")
+
+        if not isinstance(data, dict):
+            raise ConfigError(f"Manifest {path} must be a YAML object (dict)")
+
+        return Manifest.from_dict(data, source_path=path)
+
+    def get_default(self) -> Manifest:
+        """Get the default manifest.
+
+        Checks for site-config/manifests/default.yaml first,
+        then falls back to DEFAULT_MANIFEST.
+
+        Returns:
+            Default Manifest instance
+
+        Raises:
+            ConfigError: If no default manifest available
+        """
+        # Check for explicit default.yaml
+        default_path = self.manifests_dir / 'default.yaml'
+        if default_path.exists():
+            return self.load_file(default_path)
+
+        # Fall back to built-in default
+        return self.load(DEFAULT_MANIFEST)
+
+
+def load_manifest(
+    name: Optional[str] = None,
+    file_path: Optional[str] = None,
+    json_str: Optional[str] = None,
+    depth: Optional[int] = None
+) -> Manifest:
+    """Load manifest from various sources.
+
+    Priority:
+    1. json_str - Inline JSON (for recursion)
+    2. file_path - Specific file path
+    3. name - Named manifest from site-config/manifests/
+    4. Default manifest
+
+    Args:
+        name: Manifest name (without .yaml extension)
+        file_path: Path to manifest file
+        json_str: Inline JSON manifest string
+        depth: Optional depth limit (use first N levels)
+
+    Returns:
+        Manifest instance
+
+    Raises:
+        ConfigError: If manifest not found or invalid
+    """
+    if json_str:
+        manifest = Manifest.from_json(json_str)
+    elif file_path:
+        loader = ManifestLoader()
+        manifest = loader.load_file(Path(file_path))
+    elif name:
+        loader = ManifestLoader()
+        manifest = loader.load(name)
+    else:
+        loader = ManifestLoader()
+        manifest = loader.get_default()
+
+    # Apply depth limit if specified
+    if depth is not None and depth > 0:
+        if depth < len(manifest.levels):
+            manifest = Manifest(
+                schema_version=manifest.schema_version,
+                name=f"{manifest.name}[:{depth}]",
+                description=manifest.description,
+                levels=manifest.levels[:depth],
+                settings=manifest.settings,
+                source_path=manifest.source_path
+            )
+
+    return manifest

--- a/src/scenarios/__init__.py
+++ b/src/scenarios/__init__.py
@@ -191,3 +191,4 @@ from scenarios import pve_setup  # noqa: E402, F401
 from scenarios import user_setup  # noqa: E402, F401
 from scenarios import bootstrap  # noqa: E402, F401
 from scenarios import packer_build  # noqa: E402, F401
+from scenarios import recursive_pve  # noqa: E402, F401

--- a/src/scenarios/recursive_pve.py
+++ b/src/scenarios/recursive_pve.py
@@ -1,0 +1,976 @@
+"""Recursive PVE scenarios with manifest-driven depth.
+
+These scenarios use RecursiveScenarioAction to execute scenarios on nested
+bootstrapped hosts, enabling N-level nesting defined by manifest configuration.
+
+Key differences from nested-pve scenarios:
+- Manifest-driven: N is data, not code
+- Uses RecursiveScenarioAction: SSH streaming with --json-output
+- Uses bootstrap: Inner hosts install homestak, not file sync
+
+Scenarios:
+- recursive-pve-constructor: Build N-level stack per manifest
+- recursive-pve-destructor: Tear down stack (reverse order)
+- recursive-pve-roundtrip: Constructor + verify + destructor
+"""
+
+import logging
+import os
+import time
+from dataclasses import dataclass
+from typing import Optional
+
+from actions import (
+    TofuApplyAction,
+    TofuDestroyAction,
+    StartVMAction,
+    WaitForGuestAgentAction,
+    WaitForSSHAction,
+    RecursiveScenarioAction,
+    DownloadGitHubReleaseAction,
+)
+from common import ActionResult, run_ssh
+from config import HostConfig
+from manifest import Manifest, ManifestLevel, load_manifest
+from scenarios import register_scenario
+
+logger = logging.getLogger(__name__)
+
+
+# Default timeout for recursive scenario execution
+DEFAULT_RECURSIVE_TIMEOUT = 1200
+
+
+def _image_to_asset_name(image: str) -> str:
+    """Convert manifest image name to packer asset filename.
+
+    Maps image names from manifests/envs to packer release asset names:
+    - debian-12 → debian-12-custom.qcow2
+    - debian-13-pve → debian-13-pve.qcow2
+
+    Args:
+        image: Image name from manifest (e.g., 'debian-12', 'debian-13-pve')
+
+    Returns:
+        Packer release asset filename (e.g., 'debian-12-custom.qcow2')
+    """
+    # If image already has -custom or -pve suffix, use as-is
+    if image.endswith('-custom') or image.endswith('-pve'):
+        return f"{image}.qcow2"
+    # Otherwise, append -custom
+    return f"{image}-custom.qcow2"
+
+
+@dataclass
+class CreateApiTokenAction:
+    """Create API token on inner PVE and inject into secrets.yaml.
+
+    This action:
+    1. Regenerates PVE SSL certificates (IPv6 workaround)
+    2. Restarts pveproxy
+    3. Creates tofu API token via pveum
+    4. Injects token into secrets.yaml
+    """
+    name: str
+    host_attr: str = 'vm_ip'
+    token_name: str = 'nested-pve'  # Token key in secrets.yaml
+    timeout: int = 120
+
+    def run(self, config: HostConfig, context: dict) -> ActionResult:
+        """Create API token and inject into secrets.yaml."""
+        start = time.time()
+
+        host = context.get(self.host_attr)
+        if not host:
+            return ActionResult(
+                success=False,
+                message=f"No {self.host_attr} in context",
+                duration=time.time() - start
+            )
+
+        logger.info(f"[{self.name}] Creating API token on {host}...")
+
+        # Step 1: Regenerate PVE SSL certificates and restart pveproxy
+        # This fixes IPv6-related SSL issues on fresh installs
+        ssl_cmd = '''
+sysctl -w net.ipv6.conf.all.disable_ipv6=1
+sysctl -w net.ipv6.conf.default.disable_ipv6=1
+pvecm updatecerts --force 2>/dev/null || true
+sysctl -w net.ipv6.conf.all.disable_ipv6=0
+sysctl -w net.ipv6.conf.default.disable_ipv6=0
+systemctl restart pveproxy
+sleep 2
+'''
+        rc, out, err = run_ssh(host, ssl_cmd, user='root', timeout=60)
+        if rc != 0:
+            logger.warning(f"[{self.name}] SSL cert regen warning: {err or out}")
+            # Continue anyway - this might fail on some systems
+
+        # Step 2: Delete any existing token and create new one
+        token_cmd = '''
+pveum user token remove root@pam tofu 2>/dev/null || true
+pveum user token add root@pam tofu --privsep 0 --output-format json
+'''
+        rc, out, err = run_ssh(host, token_cmd, user='root', timeout=30)
+        if rc != 0:
+            return ActionResult(
+                success=False,
+                message=f"Failed to create API token: {err or out}",
+                duration=time.time() - start
+            )
+
+        # Step 3: Parse the token from JSON output
+        import json
+        try:
+            token_data = json.loads(out.strip())
+            full_token = f"{token_data['full-tokenid']}={token_data['value']}"
+        except (json.JSONDecodeError, KeyError) as e:
+            return ActionResult(
+                success=False,
+                message=f"Failed to parse API token: {e}",
+                duration=time.time() - start
+            )
+
+        # Step 4: Inject token into secrets.yaml on the inner host
+        # Use sed to update the nested-pve line under api_tokens
+        inject_cmd = f'''
+sed -i 's|^\\(\\s*\\){self.token_name}:.*$|\\1{self.token_name}: {full_token}|' /usr/local/etc/homestak/secrets.yaml
+'''
+        rc, out, err = run_ssh(host, inject_cmd, user='root', timeout=30)
+        if rc != 0:
+            return ActionResult(
+                success=False,
+                message=f"Failed to inject token into secrets.yaml: {err or out}",
+                duration=time.time() - start
+            )
+
+        logger.info(f"[{self.name}] API token created and injected on {host}")
+        return ActionResult(
+            success=True,
+            message=f"API token created on {host}",
+            duration=time.time() - start
+        )
+
+
+@dataclass
+class BootstrapAction:
+    """Bootstrap homestak on a remote host.
+
+    Runs the bootstrap curl|bash installer on a target host. Integrates with
+    serve-repos infrastructure when HOMESTAK_SOURCE env var is set.
+
+    Environment variables (from --serve-repos):
+    - HOMESTAK_SOURCE: HTTP server URL for local repo access
+    - HOMESTAK_TOKEN: Bearer token for authentication
+    - HOMESTAK_REF: Git ref to use (default: _working)
+    """
+    name: str
+    host_attr: str = 'vm_ip'
+    source_url: Optional[str] = None  # HTTP server URL for dev workflow
+    ref: str = 'master'  # Git ref for bootstrap
+    timeout: int = 600
+
+    def run(self, config: HostConfig, context: dict) -> ActionResult:
+        """Run bootstrap on target host."""
+        start = time.time()
+
+        host = context.get(self.host_attr)
+        if not host:
+            return ActionResult(
+                success=False,
+                message=f"No {self.host_attr} in context",
+                duration=time.time() - start
+            )
+
+        # Check for serve-repos env vars (dev workflow)
+        env_source = os.environ.get('HOMESTAK_SOURCE')
+        env_token = os.environ.get('HOMESTAK_TOKEN')
+        env_ref = os.environ.get('HOMESTAK_REF', '_working')
+
+        # Build bootstrap command
+        if env_source:
+            # Dev workflow: use HTTP server from --serve-repos
+            # Pass env vars to bash (not curl) so install.sh uses local (uncommitted) code
+            # The env vars must be set for bash, which receives curl's output
+            env_prefix = f'HOMESTAK_SOURCE={env_source}'
+            if env_token:
+                env_prefix += f' HOMESTAK_TOKEN={env_token}'
+            env_prefix += f' HOMESTAK_REF={env_ref}'
+            # Include Bearer token in curl header (serve-repos requires auth)
+            auth_header = f'-H "Authorization: Bearer {env_token}"' if env_token else ''
+            # IMPORTANT: env_prefix goes before 'bash', not 'curl', so the vars are in bash's environment
+            bootstrap_cmd = f'curl -fsSL {auth_header} {env_source}/bootstrap.git/install.sh | {env_prefix} bash'
+            logger.info(f"[{self.name}] Using serve-repos source: {env_source} (ref={env_ref})")
+        elif self.source_url:
+            # Explicit source_url parameter (legacy)
+            bootstrap_cmd = f'curl -fsSL {self.source_url}/install.sh | bash'
+        else:
+            # Production: use GitHub
+            bootstrap_url = 'https://raw.githubusercontent.com/homestak-dev/bootstrap'
+            bootstrap_cmd = f'curl -fsSL {bootstrap_url}/{self.ref}/install.sh | bash'
+
+        logger.info(f"[{self.name}] Bootstrapping {host}...")
+
+        # Run bootstrap
+        rc, out, err = run_ssh(
+            host,
+            bootstrap_cmd,
+            user='root',
+            timeout=self.timeout
+        )
+
+        if rc != 0:
+            return ActionResult(
+                success=False,
+                message=f"Bootstrap failed: {err or out}",
+                duration=time.time() - start
+            )
+
+        logger.info(f"[{self.name}] Bootstrap completed on {host}")
+        return ActionResult(
+            success=True,
+            message=f"Bootstrap completed on {host}",
+            duration=time.time() - start
+        )
+
+
+@dataclass
+class CopySecretsAction:
+    """Copy secrets.yaml from outer host to inner host.
+
+    Required for inner hosts to have valid API tokens and SSH keys.
+    """
+    name: str
+    host_attr: str = 'vm_ip'
+    timeout: int = 60
+
+    def run(self, config: HostConfig, context: dict) -> ActionResult:
+        """Copy secrets to target host."""
+        start = time.time()
+
+        host = context.get(self.host_attr)
+        if not host:
+            return ActionResult(
+                success=False,
+                message=f"No {self.host_attr} in context",
+                duration=time.time() - start
+            )
+
+        # Use scp to copy secrets.yaml
+        from config import get_site_config_dir
+        secrets_path = get_site_config_dir() / 'secrets.yaml'
+
+        if not secrets_path.exists():
+            return ActionResult(
+                success=False,
+                message=f"secrets.yaml not found at {secrets_path}",
+                duration=time.time() - start
+            )
+
+        logger.info(f"[{self.name}] Copying secrets to {host}...")
+
+        import subprocess
+        cmd = [
+            'scp',
+            '-o', 'StrictHostKeyChecking=no',
+            '-o', 'UserKnownHostsFile=/dev/null',
+            str(secrets_path),
+            f'root@{host}:/usr/local/etc/homestak/secrets.yaml'
+        ]
+
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=self.timeout
+            )
+
+            if result.returncode != 0:
+                return ActionResult(
+                    success=False,
+                    message=f"Failed to copy secrets: {result.stderr}",
+                    duration=time.time() - start
+                )
+
+            return ActionResult(
+                success=True,
+                message=f"Secrets copied to {host}",
+                duration=time.time() - start
+            )
+
+        except subprocess.TimeoutExpired:
+            return ActionResult(
+                success=False,
+                message=f"Timeout copying secrets to {host}",
+                duration=time.time() - start
+            )
+
+
+@dataclass
+class InjectSSHKeyAction:
+    """Inject outer host's SSH public key into inner host's secrets.yaml.
+
+    This is critical for SSH access to leaf VMs - the outer host's key must
+    be in secrets.yaml so ConfigResolver includes it in cloud-init.
+    """
+    name: str
+    host_attr: str = 'vm_ip'
+    key_name: str = 'outer_host'  # Key name in secrets.yaml ssh_keys
+    timeout: int = 60
+
+    def run(self, config: HostConfig, context: dict) -> ActionResult:
+        """Inject SSH key into target host's secrets.yaml."""
+        start = time.time()
+
+        host = context.get(self.host_attr)
+        if not host:
+            return ActionResult(
+                success=False,
+                message=f"No {self.host_attr} in context",
+                duration=time.time() - start
+            )
+
+        # Read local SSH public key
+        from pathlib import Path
+        pubkey_path = Path.home() / '.ssh' / 'id_rsa.pub'
+        if not pubkey_path.exists():
+            pubkey_path = Path.home() / '.ssh' / 'id_ed25519.pub'
+        if not pubkey_path.exists():
+            return ActionResult(
+                success=False,
+                message="No SSH public key found (~/.ssh/id_rsa.pub or id_ed25519.pub)",
+                duration=time.time() - start
+            )
+
+        pubkey = pubkey_path.read_text().strip()
+        logger.info(f"[{self.name}] Injecting SSH key ({self.key_name}) to {host}...")
+
+        # Escape the key for sed (forward slashes and ampersands)
+        escaped_key = pubkey.replace('/', r'\/').replace('&', r'\&')
+
+        # Inject key into secrets.yaml using sed
+        # First check if outer_host already exists
+        check_cmd = f"grep -q '^\\s*{self.key_name}:' /usr/local/etc/homestak/secrets.yaml"
+        rc, _, _ = run_ssh(host, check_cmd, user='root', timeout=30)
+
+        if rc == 0:
+            # Key exists, update it
+            inject_cmd = f"sed -i 's|^\\(\\s*\\){self.key_name}:.*$|\\1{self.key_name}: {escaped_key}|' /usr/local/etc/homestak/secrets.yaml"
+        else:
+            # Key doesn't exist, add it after ssh_keys:
+            inject_cmd = f"sed -i '/^ssh_keys:/a\\    {self.key_name}: {escaped_key}' /usr/local/etc/homestak/secrets.yaml"
+
+        rc, out, err = run_ssh(host, inject_cmd, user='root', timeout=self.timeout)
+        if rc != 0:
+            return ActionResult(
+                success=False,
+                message=f"Failed to inject SSH key: {err or out}",
+                duration=time.time() - start
+            )
+
+        # Verify the key was injected
+        verify_cmd = f"grep -q '{self.key_name}:' /usr/local/etc/homestak/secrets.yaml"
+        rc, _, _ = run_ssh(host, verify_cmd, user='root', timeout=30)
+        if rc != 0:
+            return ActionResult(
+                success=False,
+                message="SSH key injection verification failed",
+                duration=time.time() - start
+            )
+
+        logger.info(f"[{self.name}] SSH key injected on {host}")
+        return ActionResult(
+            success=True,
+            message=f"SSH key ({self.key_name}) injected on {host}",
+            duration=time.time() - start
+        )
+
+
+@dataclass
+class InjectSelfSSHKeyAction:
+    """Inject a host's own SSH public key into its secrets.yaml.
+
+    This enables the host to SSH to VMs it provisions - the VM's cloud-init
+    will include this key in authorized_keys.
+    """
+    name: str
+    host_attr: str = 'vm_ip'
+    key_name: str = 'inner_host'  # Key name in secrets.yaml ssh_keys
+    timeout: int = 60
+
+    def run(self, config: HostConfig, context: dict) -> ActionResult:
+        """Inject host's own SSH key into its secrets.yaml."""
+        start = time.time()
+
+        host = context.get(self.host_attr)
+        if not host:
+            return ActionResult(
+                success=False,
+                message=f"No {self.host_attr} in context",
+                duration=time.time() - start
+            )
+
+        logger.info(f"[{self.name}] Injecting {host}'s own SSH key as {self.key_name}...")
+
+        # Inject via Python script encoded in base64 to avoid shell quoting issues
+        python_script = f'''
+import sys
+key_name = sys.argv[1]
+secrets_file = "/usr/local/etc/homestak/secrets.yaml"
+
+# Find public key
+pubkey = None
+for keyfile in ["/root/.ssh/id_ed25519.pub", "/root/.ssh/id_rsa.pub"]:
+    try:
+        with open(keyfile) as f:
+            pubkey = f.read().strip()
+            break
+    except FileNotFoundError:
+        continue
+
+if not pubkey:
+    print("No SSH public key found")
+    sys.exit(1)
+
+with open(secrets_file, "r") as f:
+    lines = f.readlines()
+
+key_exists = any(key_name + ":" in line for line in lines)
+
+with open(secrets_file, "w") as f:
+    for line in lines:
+        if key_name + ":" in line:
+            indent = len(line) - len(line.lstrip())
+            f.write(" " * indent + key_name + ": " + pubkey + "\\n")
+        else:
+            f.write(line)
+            if not key_exists and line.strip() == "ssh_keys:":
+                f.write("    " + key_name + ": " + pubkey + "\\n")
+                key_exists = True
+
+# Verify
+with open(secrets_file, "r") as f:
+    if key_name + ":" not in f.read():
+        print("Verification failed")
+        sys.exit(1)
+print(f"Injected {{key_name}}")
+'''
+        import base64
+        encoded = base64.b64encode(python_script.encode()).decode()
+        inject_script = f"echo '{encoded}' | base64 -d | python3 - {self.key_name}"
+
+        rc, out, err = run_ssh(host, inject_script, user='root', timeout=self.timeout)
+        if rc != 0:
+            return ActionResult(
+                success=False,
+                message=f"Failed to inject self SSH key: {err or out}",
+                duration=time.time() - start
+            )
+
+        logger.info(f"[{self.name}] Self SSH key injected on {host}")
+        return ActionResult(
+            success=True,
+            message=f"Self SSH key ({self.key_name}) injected on {host}",
+            duration=time.time() - start
+        )
+
+
+@dataclass
+class ConfigureNetworkBridgeAction:
+    """Configure vmbr0 network bridge on inner PVE.
+
+    Creates vmbr0 bridge from eth0 (required for nested VMs to get network).
+    Uses a simple shell script rather than ansible for speed.
+    """
+    name: str
+    host_attr: str = 'vm_ip'
+    timeout: int = 120
+
+    def run(self, config: HostConfig, context: dict) -> ActionResult:
+        """Configure vmbr0 bridge on target host."""
+        start = time.time()
+
+        host = context.get(self.host_attr)
+        if not host:
+            return ActionResult(
+                success=False,
+                message=f"No {self.host_attr} in context",
+                duration=time.time() - start
+            )
+
+        logger.info(f"[{self.name}] Configuring vmbr0 bridge on {host}...")
+
+        # Check if vmbr0 already exists
+        check_cmd = "ip link show vmbr0 2>/dev/null && ip addr show vmbr0 | grep -q 'inet '"
+        rc, out, err = run_ssh(host, check_cmd, user='root', timeout=30)
+        if rc == 0:
+            logger.info(f"[{self.name}] vmbr0 already exists on {host}")
+            return ActionResult(
+                success=True,
+                message=f"vmbr0 already configured on {host}",
+                duration=time.time() - start
+            )
+
+        # Script to create vmbr0 bridge from eth0 with DHCP
+        # This preserves the current IP during transition
+        bridge_script = '''
+set -e
+
+# Get current interface info
+IFACE=$(ip -o route get 8.8.8.8 2>/dev/null | grep -oP 'dev \\K\\S+' || echo eth0)
+echo "Detected interface: $IFACE"
+
+# Backup interfaces
+cp /etc/network/interfaces /etc/network/interfaces.backup.$(date +%s) 2>/dev/null || true
+
+# Create bridge config with DHCP
+cat > /etc/network/interfaces << 'IFACE_EOF'
+auto lo
+iface lo inet loopback
+
+iface eth0 inet manual
+
+auto vmbr0
+iface vmbr0 inet dhcp
+    bridge-ports eth0
+    bridge-stp off
+    bridge-fd 0
+IFACE_EOF
+
+# Apply network configuration
+# Use systemctl to restart networking
+systemctl restart networking 2>/dev/null || ifdown eth0; ifup vmbr0
+
+# Wait for bridge to get IP
+for i in $(seq 1 30); do
+    if ip addr show vmbr0 | grep -q 'inet '; then
+        echo "vmbr0 configured successfully"
+        ip addr show vmbr0 | grep 'inet '
+        exit 0
+    fi
+    sleep 1
+done
+
+echo "Warning: vmbr0 did not get IP within 30s"
+exit 0
+'''
+
+        rc, out, err = run_ssh(host, bridge_script, user='root', timeout=self.timeout)
+        if rc != 0:
+            return ActionResult(
+                success=False,
+                message=f"Failed to configure vmbr0: {err or out}",
+                duration=time.time() - start
+            )
+
+        logger.info(f"[{self.name}] vmbr0 configured on {host}")
+        return ActionResult(
+            success=True,
+            message=f"vmbr0 bridge configured on {host}",
+            duration=time.time() - start
+        )
+
+
+@dataclass
+class GenerateNodeConfigAction:
+    """Generate node config on inner host.
+
+    Runs 'make node-config' on the inner host to generate the
+    nodes/{hostname}.yaml file needed for tofu operations.
+    """
+    name: str
+    host_attr: str = 'vm_ip'
+    timeout: int = 120
+
+    def run(self, config: HostConfig, context: dict) -> ActionResult:
+        """Generate node config on target host."""
+        start = time.time()
+
+        host = context.get(self.host_attr)
+        if not host:
+            return ActionResult(
+                success=False,
+                message=f"No {self.host_attr} in context",
+                duration=time.time() - start
+            )
+
+        logger.info(f"[{self.name}] Generating node config on {host}...")
+
+        # Use FORCE=1 in case node config was copied from outer host
+        cmd = 'cd /usr/local/etc/homestak && make node-config FORCE=1'
+        rc, out, err = run_ssh(host, cmd, user='root', timeout=self.timeout)
+
+        if rc != 0:
+            return ActionResult(
+                success=False,
+                message=f"Failed to generate node config: {err or out}",
+                duration=time.time() - start
+            )
+
+        return ActionResult(
+            success=True,
+            message=f"Node config generated on {host}",
+            duration=time.time() - start
+        )
+
+
+class RecursivePVEBase:
+    """Base class for recursive PVE scenarios with manifest support.
+
+    Attributes:
+        manifest: Loaded manifest defining recursion levels
+        keep_on_failure: If True, don't cleanup on failure (for debugging)
+            Set by --keep-on-failure CLI flag or manifest settings.cleanup_on_failure
+    """
+
+    # To be set by subclasses or CLI
+    manifest: Optional[Manifest] = None
+    keep_on_failure: bool = False
+
+    def _get_effective_keep_on_failure(self) -> bool:
+        """Get effective keep_on_failure value.
+
+        CLI --keep-on-failure flag takes precedence over manifest setting.
+        Manifest cleanup_on_failure=false means keep_on_failure=true.
+        """
+        # CLI flag takes precedence (if set to True)
+        if self.keep_on_failure:
+            return True
+        # Otherwise, invert manifest setting (cleanup_on_failure=false -> keep=true)
+        if self.manifest and not self.manifest.settings.cleanup_on_failure:
+            return True
+        return False
+
+    def _get_recursive_timeout(self, base_timeout: int = DEFAULT_RECURSIVE_TIMEOUT) -> int:
+        """Get timeout for recursive actions, applying timeout_buffer.
+
+        Each level gets base_timeout minus timeout_buffer to ensure outer
+        levels have time for cleanup if inner levels timeout.
+        """
+        if self.manifest:
+            buffer = self.manifest.settings.timeout_buffer
+            return max(base_timeout - buffer, 60)  # Minimum 60s
+        return base_timeout
+
+    def get_level_phases(
+        self,
+        level: ManifestLevel,
+        config: HostConfig,
+        remaining_manifest: Optional[Manifest] = None,
+        is_leaf: bool = False
+    ) -> list[tuple[str, object, str]]:
+        """Get phases for a single level.
+
+        Args:
+            level: Current level from manifest
+            config: Host config
+            remaining_manifest: Manifest with remaining levels (for recursion)
+            is_leaf: True if this is the leaf level (no children)
+
+        Returns:
+            List of (phase_name, action, description) tuples
+        """
+        phases = []
+        host_key = f'{level.name}_ip'
+        vm_id_key = f'{level.name}_vm_id'
+
+        # Phase 1: Provision VM using tofu
+        phases.append((
+            f'provision_{level.name}',
+            TofuApplyAction(
+                name=f'provision-{level.name}',
+                env_name=level.env,
+                image_override=level.image,
+                vmid_offset=level.vmid_offset,
+                context_prefix=level.name,  # Use level name for context keys
+            ),
+            f'Provision {level.name}'
+        ))
+
+        # Phase 2: Start VM
+        phases.append((
+            f'start_{level.name}',
+            StartVMAction(
+                name=f'start-{level.name}',
+                vm_id_attr=vm_id_key,
+                pve_host_attr='ssh_host',
+            ),
+            f'Start {level.name}'
+        ))
+
+        # Phase 3: Wait for IP
+        phases.append((
+            f'wait_ip_{level.name}',
+            WaitForGuestAgentAction(
+                name=f'wait-ip-{level.name}',
+                vm_id_attr=vm_id_key,
+                pve_host_attr='ssh_host',
+                ip_context_key=host_key,
+                timeout=300,
+            ),
+            f'Wait for {level.name} IP'
+        ))
+
+        # Phase 4: Verify SSH
+        phases.append((
+            f'verify_ssh_{level.name}',
+            WaitForSSHAction(
+                name=f'verify-ssh-{level.name}',
+                host_key=host_key,
+                timeout=120,
+            ),
+            f'Verify SSH on {level.name}'
+        ))
+
+        # If not leaf: bootstrap and recurse
+        if not is_leaf and remaining_manifest:
+            # Phase 5: Bootstrap
+            phases.append((
+                f'bootstrap_{level.name}',
+                BootstrapAction(
+                    name=f'bootstrap-{level.name}',
+                    host_attr=host_key,
+                    timeout=600,
+                ),
+                f'Bootstrap {level.name}'
+            ))
+
+            # Phase 6: Copy secrets
+            phases.append((
+                f'secrets_{level.name}',
+                CopySecretsAction(
+                    name=f'secrets-{level.name}',
+                    host_attr=host_key,
+                ),
+                f'Copy secrets to {level.name}'
+            ))
+
+            # Phase 6b: Inject outer host SSH key for leaf VM access
+            phases.append((
+                f'sshkey_{level.name}',
+                InjectSSHKeyAction(
+                    name=f'sshkey-{level.name}',
+                    host_attr=host_key,
+                ),
+                f'Inject SSH key on {level.name}'
+            ))
+
+            # Phase 7: Run post_scenario (e.g., pve-setup) - installs PVE
+            if level.post_scenario:
+                phases.append((
+                    f'post_{level.name}',
+                    RecursiveScenarioAction(
+                        name=f'post-{level.name}',
+                        scenario_name=level.post_scenario,
+                        host_attr=host_key,
+                        scenario_args=level.post_scenario_args,
+                        timeout=self._get_recursive_timeout(600),
+                    ),
+                    f'Run {level.post_scenario} on {level.name}'
+                ))
+
+            # Phase 8: Configure vmbr0 bridge (required for nested VMs)
+            phases.append((
+                f'network_{level.name}',
+                ConfigureNetworkBridgeAction(
+                    name=f'network-{level.name}',
+                    host_attr=host_key,
+                ),
+                f'Configure vmbr0 bridge on {level.name}'
+            ))
+
+            # Phase 9: Generate node config (requires PVE installed)
+            phases.append((
+                f'nodeconfig_{level.name}',
+                GenerateNodeConfigAction(
+                    name=f'nodeconfig-{level.name}',
+                    host_attr=host_key,
+                ),
+                f'Generate node config on {level.name}'
+            ))
+
+            # Phase 9: Create API token and inject into secrets.yaml
+            phases.append((
+                f'apitoken_{level.name}',
+                CreateApiTokenAction(
+                    name=f'apitoken-{level.name}',
+                    host_attr=host_key,
+                ),
+                f'Create API token on {level.name}'
+            ))
+
+            # Phase 9b: Inject inner host's own SSH key for VM access
+            # This enables the inner host to SSH to VMs it provisions
+            phases.append((
+                f'selfsshkey_{level.name}',
+                InjectSelfSSHKeyAction(
+                    name=f'selfsshkey-{level.name}',
+                    host_attr=host_key,
+                ),
+                f'Inject {level.name} SSH key'
+            ))
+
+            # Phase 10: Download packer image for next level
+            next_level = remaining_manifest.get_current_level()
+            # Get image from next level (fall back to debian-12 if not specified)
+            next_image = next_level.image or 'debian-12'
+            next_asset = _image_to_asset_name(next_image)
+            phases.append((
+                f'download_image_{next_level.name}',
+                DownloadGitHubReleaseAction(
+                    name=f'download-image-{next_level.name}',
+                    asset_name=next_asset,
+                    dest_dir='/var/lib/vz/template/iso',
+                    host_key=host_key,
+                    rename_ext='.img',
+                    timeout=300,
+                ),
+                f'Download {next_asset} for {next_level.name}'
+            ))
+
+            # Phase 11: Recurse to next level
+            # Build args for recursive call
+            # Use current level's env as the host (assumes single-VM env where VM name = env name)
+            # Skip preflight on recursive calls - API may not be fully ready after pve-setup
+            recurse_args = ['--host', level.env, '--manifest-json', remaining_manifest.to_json(), '--skip-preflight']
+            # Propagate keep_on_failure setting
+            if self._get_effective_keep_on_failure():
+                recurse_args.append('--keep-on-failure')
+
+            phases.append((
+                f'recurse_{next_level.name}',
+                RecursiveScenarioAction(
+                    name=f'recurse-{next_level.name}',
+                    scenario_name='recursive-pve-constructor',
+                    host_attr=host_key,
+                    scenario_args=recurse_args,
+                    context_keys=[f'{next_level.name}_ip', f'{next_level.name}_vm_id'],
+                    timeout=self._get_recursive_timeout(),
+                ),
+                f'Build {next_level.name}'
+            ))
+
+        return phases
+
+
+@register_scenario
+class RecursivePVEConstructor(RecursivePVEBase):
+    """Build N-level nested PVE stack from manifest."""
+
+    name = 'recursive-pve-constructor'
+    description = 'Build N-level nested PVE stack per manifest'
+    expected_runtime = 360  # ~6 min for N=2
+
+    def get_phases(self, config: HostConfig) -> list[tuple[str, object, str]]:
+        """Return phases for recursive construction."""
+        # Load manifest from context or default
+        # Note: In recursive calls, manifest comes from --manifest-json
+        if self.manifest is None:
+            self.manifest = load_manifest()
+
+        level = self.manifest.get_current_level()
+
+        if self.manifest.is_leaf:
+            # Leaf level: just provision, start, verify
+            return self.get_level_phases(level, config, is_leaf=True)
+        else:
+            # Non-leaf: provision, bootstrap, recurse
+            remaining = self.manifest.get_remaining_manifest()
+            return self.get_level_phases(level, config, remaining, is_leaf=False)
+
+
+@register_scenario
+class RecursivePVEDestructor(RecursivePVEBase):
+    """Tear down N-level nested PVE stack."""
+
+    name = 'recursive-pve-destructor'
+    description = 'Destroy N-level nested PVE stack'
+    expected_runtime = 120  # ~2 min
+    requires_confirmation = True
+
+    def get_phases(self, config: HostConfig) -> list[tuple[str, object, str]]:
+        """Return phases for recursive destruction.
+
+        Destruction happens in reverse order - destroy innermost first.
+        """
+        if self.manifest is None:
+            self.manifest = load_manifest()
+
+        phases = []
+
+        # For destruction, we need to destroy in reverse order
+        # First, recurse to destroy inner levels (if any)
+        if not self.manifest.is_leaf:
+            level = self.manifest.get_current_level()
+            host_key = f'{level.name}_ip'
+            remaining = self.manifest.get_remaining_manifest()
+
+            # Build args for recursive call
+            # Use current level's env as the host (assumes single-VM env where VM name = env name)
+            # Skip preflight on recursive calls - we're already inside a running scenario
+            recurse_args = [
+                '--host', level.env,
+                '--manifest-json', remaining.to_json(),
+                '--yes',  # Already confirmed at outer level
+                '--skip-preflight'
+            ]
+
+            # Recurse to destroy inner levels first
+            phases.append((
+                f'recurse_destroy',
+                RecursiveScenarioAction(
+                    name='recurse-destroy',
+                    scenario_name='recursive-pve-destructor',
+                    host_attr=host_key,
+                    scenario_args=recurse_args,
+                    timeout=self._get_recursive_timeout(600),
+                ),
+                'Destroy inner levels'
+            ))
+
+        # Then destroy this level (outermost for this invocation)
+        level = self.manifest.get_current_level()
+        phases.append((
+            f'destroy_{level.name}',
+            TofuDestroyAction(
+                name=f'destroy-{level.name}',
+                env_name=level.env,
+            ),
+            f'Destroy {level.name}'
+        ))
+
+        return phases
+
+
+@register_scenario
+class RecursivePVERoundtrip(RecursivePVEBase):
+    """Full roundtrip: construct, verify, destruct."""
+
+    name = 'recursive-pve-roundtrip'
+    description = 'Build N-level stack, verify, destroy (full cycle)'
+    expected_runtime = 540  # ~9 min for N=2
+
+    def get_phases(self, config: HostConfig) -> list[tuple[str, object, str]]:
+        """Return phases for full roundtrip.
+
+        Combines constructor phases with destructor phases.
+        """
+        if self.manifest is None:
+            self.manifest = load_manifest()
+
+        # Get all construction phases
+        constructor = RecursivePVEConstructor()
+        constructor.manifest = self.manifest
+        phases = constructor.get_phases(config)
+
+        # Add destruction phases
+        destructor = RecursivePVEDestructor()
+        destructor.manifest = self.manifest
+        destroy_phases = destructor.get_phases(config)
+
+        # Prefix destruction phase names to avoid conflicts
+        for name, action, desc in destroy_phases:
+            phases.append((f'cleanup_{name}', action, f'Cleanup: {desc}'))
+
+        return phases

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,0 +1,485 @@
+#!/usr/bin/env python3
+"""Tests for manifest.py - recursion manifest loading and validation.
+
+Tests verify:
+1. Manifest dataclass creation
+2. Schema validation
+3. Level parsing
+4. YAML file loading
+5. JSON serialization/deserialization
+6. Depth limiting
+"""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+import tempfile
+
+sys.path.insert(0, str(Path(__file__).parent.parent / 'src'))
+
+import pytest
+from config import ConfigError
+
+
+class TestManifestLevel:
+    """Test ManifestLevel dataclass."""
+
+    def test_from_dict_minimal(self):
+        """Should create level with minimal required fields."""
+        from manifest import ManifestLevel
+
+        data = {'name': 'inner-pve', 'env': 'nested-pve'}
+        level = ManifestLevel.from_dict(data)
+
+        assert level.name == 'inner-pve'
+        assert level.env == 'nested-pve'
+        assert level.image is None
+        assert level.vmid_offset == 0
+        assert level.post_scenario is None
+        assert level.post_scenario_args == []
+
+    def test_from_dict_full(self):
+        """Should create level with all fields."""
+        from manifest import ManifestLevel
+
+        data = {
+            'name': 'inner-pve',
+            'env': 'nested-pve',
+            'image': 'debian-13-pve',
+            'vmid_offset': 100,
+            'post_scenario': 'pve-setup',
+            'post_scenario_args': ['--local']
+        }
+        level = ManifestLevel.from_dict(data)
+
+        assert level.name == 'inner-pve'
+        assert level.env == 'nested-pve'
+        assert level.image == 'debian-13-pve'
+        assert level.vmid_offset == 100
+        assert level.post_scenario == 'pve-setup'
+        assert level.post_scenario_args == ['--local']
+
+
+class TestManifestSettings:
+    """Test ManifestSettings dataclass."""
+
+    def test_defaults(self):
+        """Should have sensible defaults."""
+        from manifest import ManifestSettings
+
+        settings = ManifestSettings()
+
+        assert settings.verify_ssh is True
+        assert settings.cleanup_on_failure is True
+        assert settings.timeout_buffer == 60
+
+    def test_from_dict_none(self):
+        """Should return defaults for None input."""
+        from manifest import ManifestSettings
+
+        settings = ManifestSettings.from_dict(None)
+
+        assert settings.verify_ssh is True
+        assert settings.cleanup_on_failure is True
+
+    def test_from_dict_partial(self):
+        """Should apply partial overrides."""
+        from manifest import ManifestSettings
+
+        settings = ManifestSettings.from_dict({'cleanup_on_failure': False})
+
+        assert settings.verify_ssh is True  # default
+        assert settings.cleanup_on_failure is False  # overridden
+
+
+class TestManifest:
+    """Test Manifest dataclass."""
+
+    def test_from_dict_minimal(self):
+        """Should create manifest with minimal required fields."""
+        from manifest import Manifest
+
+        data = {
+            'name': 'test',
+            'levels': [
+                {'name': 'level1', 'env': 'test'}
+            ]
+        }
+        manifest = Manifest.from_dict(data)
+
+        assert manifest.schema_version == 1
+        assert manifest.name == 'test'
+        assert manifest.description == ''
+        assert len(manifest.levels) == 1
+        assert manifest.levels[0].name == 'level1'
+
+    def test_from_dict_full(self):
+        """Should create manifest with all fields."""
+        from manifest import Manifest
+
+        data = {
+            'schema_version': 1,
+            'name': 'n2-quick',
+            'description': 'Quick test',
+            'levels': [
+                {'name': 'inner', 'env': 'nested-pve', 'image': 'debian-13-pve'},
+                {'name': 'leaf', 'env': 'test'}
+            ],
+            'settings': {
+                'verify_ssh': False,
+                'cleanup_on_failure': False,
+                'timeout_buffer': 30
+            }
+        }
+        manifest = Manifest.from_dict(data)
+
+        assert manifest.schema_version == 1
+        assert manifest.name == 'n2-quick'
+        assert manifest.description == 'Quick test'
+        assert len(manifest.levels) == 2
+        assert manifest.settings.verify_ssh is False
+        assert manifest.settings.cleanup_on_failure is False
+        assert manifest.settings.timeout_buffer == 30
+
+    def test_missing_name_raises_error(self):
+        """Should raise error when name missing."""
+        from manifest import Manifest
+
+        data = {'levels': [{'name': 'level1', 'env': 'test'}]}
+
+        with pytest.raises(ConfigError, match='missing required field: name'):
+            Manifest.from_dict(data)
+
+    def test_missing_levels_raises_error(self):
+        """Should raise error when levels missing."""
+        from manifest import Manifest
+
+        data = {'name': 'test'}
+
+        with pytest.raises(ConfigError, match='missing required field: levels'):
+            Manifest.from_dict(data)
+
+    def test_empty_levels_raises_error(self):
+        """Should raise error when levels empty."""
+        from manifest import Manifest
+
+        data = {'name': 'test', 'levels': []}
+
+        with pytest.raises(ConfigError, match='must have at least one level'):
+            Manifest.from_dict(data)
+
+    def test_unsupported_schema_version(self):
+        """Should raise error for unsupported schema version."""
+        from manifest import Manifest
+
+        data = {
+            'schema_version': 99,
+            'name': 'test',
+            'levels': [{'name': 'level1', 'env': 'test'}]
+        }
+
+        with pytest.raises(ConfigError, match='Unsupported manifest schema version'):
+            Manifest.from_dict(data)
+
+    def test_level_missing_name(self):
+        """Should raise error when level missing name."""
+        from manifest import Manifest
+
+        data = {
+            'name': 'test',
+            'levels': [{'env': 'test'}]
+        }
+
+        with pytest.raises(ConfigError, match='Level 0 missing required field: name'):
+            Manifest.from_dict(data)
+
+    def test_level_missing_env(self):
+        """Should raise error when level missing env."""
+        from manifest import Manifest
+
+        data = {
+            'name': 'test',
+            'levels': [{'name': 'level1'}]
+        }
+
+        with pytest.raises(ConfigError, match='missing required field: env'):
+            Manifest.from_dict(data)
+
+
+class TestManifestProperties:
+    """Test Manifest property methods."""
+
+    def test_depth(self):
+        """Should return correct depth."""
+        from manifest import Manifest
+
+        data = {
+            'name': 'test',
+            'levels': [
+                {'name': 'l1', 'env': 'test'},
+                {'name': 'l2', 'env': 'test'},
+                {'name': 'l3', 'env': 'test'}
+            ]
+        }
+        manifest = Manifest.from_dict(data)
+
+        assert manifest.depth == 3
+
+    def test_is_leaf_true(self):
+        """Should return True for single-level manifest."""
+        from manifest import Manifest
+
+        data = {
+            'name': 'test',
+            'levels': [{'name': 'leaf', 'env': 'test'}]
+        }
+        manifest = Manifest.from_dict(data)
+
+        assert manifest.is_leaf is True
+
+    def test_is_leaf_false(self):
+        """Should return False for multi-level manifest."""
+        from manifest import Manifest
+
+        data = {
+            'name': 'test',
+            'levels': [
+                {'name': 'l1', 'env': 'test'},
+                {'name': 'l2', 'env': 'test'}
+            ]
+        }
+        manifest = Manifest.from_dict(data)
+
+        assert manifest.is_leaf is False
+
+    def test_get_current_level(self):
+        """Should return first level."""
+        from manifest import Manifest
+
+        data = {
+            'name': 'test',
+            'levels': [
+                {'name': 'first', 'env': 'test'},
+                {'name': 'second', 'env': 'test'}
+            ]
+        }
+        manifest = Manifest.from_dict(data)
+
+        level = manifest.get_current_level()
+        assert level.name == 'first'
+
+    def test_get_remaining_manifest(self):
+        """Should return manifest without first level."""
+        from manifest import Manifest
+
+        data = {
+            'name': 'test',
+            'levels': [
+                {'name': 'first', 'env': 'env1'},
+                {'name': 'second', 'env': 'env2'},
+                {'name': 'third', 'env': 'env3'}
+            ]
+        }
+        manifest = Manifest.from_dict(data)
+
+        remaining = manifest.get_remaining_manifest()
+
+        assert remaining.depth == 2
+        assert remaining.levels[0].name == 'second'
+        assert remaining.levels[1].name == 'third'
+
+    def test_get_remaining_manifest_at_leaf_raises(self):
+        """Should raise error when at leaf level."""
+        from manifest import Manifest
+
+        data = {
+            'name': 'test',
+            'levels': [{'name': 'leaf', 'env': 'test'}]
+        }
+        manifest = Manifest.from_dict(data)
+
+        with pytest.raises(ConfigError, match='already at leaf level'):
+            manifest.get_remaining_manifest()
+
+
+class TestManifestSerialization:
+    """Test manifest serialization."""
+
+    def test_to_dict(self):
+        """Should serialize to dictionary."""
+        from manifest import Manifest
+
+        data = {
+            'schema_version': 1,
+            'name': 'test',
+            'description': 'Test manifest',
+            'levels': [{'name': 'level1', 'env': 'test'}],
+            'settings': {'verify_ssh': True}
+        }
+        manifest = Manifest.from_dict(data)
+
+        result = manifest.to_dict()
+
+        assert result['schema_version'] == 1
+        assert result['name'] == 'test'
+        assert result['description'] == 'Test manifest'
+        assert len(result['levels']) == 1
+        assert 'settings' in result
+
+    def test_to_json(self):
+        """Should serialize to JSON string."""
+        from manifest import Manifest
+
+        data = {
+            'name': 'test',
+            'levels': [{'name': 'level1', 'env': 'test'}]
+        }
+        manifest = Manifest.from_dict(data)
+
+        json_str = manifest.to_json()
+        parsed = json.loads(json_str)
+
+        assert parsed['name'] == 'test'
+        assert len(parsed['levels']) == 1
+
+    def test_from_json(self):
+        """Should deserialize from JSON string."""
+        from manifest import Manifest
+
+        json_str = '{"name": "test", "levels": [{"name": "l1", "env": "e1"}]}'
+
+        manifest = Manifest.from_json(json_str)
+
+        assert manifest.name == 'test'
+        assert len(manifest.levels) == 1
+
+    def test_roundtrip(self):
+        """Should survive JSON roundtrip."""
+        from manifest import Manifest
+
+        original = {
+            'schema_version': 1,
+            'name': 'n2-quick',
+            'description': 'Test',
+            'levels': [
+                {'name': 'inner', 'env': 'nested-pve', 'image': 'debian-13'},
+                {'name': 'leaf', 'env': 'test', 'vmid_offset': 100}
+            ],
+            'settings': {'cleanup_on_failure': False}
+        }
+        manifest = Manifest.from_dict(original)
+
+        # Roundtrip through JSON
+        json_str = manifest.to_json()
+        restored = Manifest.from_json(json_str)
+
+        assert restored.name == manifest.name
+        assert restored.depth == manifest.depth
+        assert restored.settings.cleanup_on_failure is False
+
+
+class TestManifestLoader:
+    """Test ManifestLoader class."""
+
+    def test_list_manifests(self):
+        """Should list available manifests."""
+        from manifest import ManifestLoader
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifests_dir = Path(tmpdir) / 'manifests'
+            manifests_dir.mkdir()
+
+            # Create test manifests
+            (manifests_dir / 'n2-quick.yaml').write_text('name: n2-quick\nlevels:\n  - name: l1\n    env: test\n')
+            (manifests_dir / 'n3-full.yaml').write_text('name: n3-full\nlevels:\n  - name: l1\n    env: test\n')
+
+            loader = ManifestLoader(site_config_path=tmpdir)
+            manifests = loader.list_manifests()
+
+            assert 'n2-quick' in manifests
+            assert 'n3-full' in manifests
+
+    def test_load_manifest(self):
+        """Should load manifest by name."""
+        from manifest import ManifestLoader
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifests_dir = Path(tmpdir) / 'manifests'
+            manifests_dir.mkdir()
+
+            yaml_content = """
+name: test-manifest
+description: Test description
+levels:
+  - name: inner
+    env: nested-pve
+    image: debian-13-pve
+"""
+            (manifests_dir / 'test-manifest.yaml').write_text(yaml_content)
+
+            loader = ManifestLoader(site_config_path=tmpdir)
+            manifest = loader.load('test-manifest')
+
+            assert manifest.name == 'test-manifest'
+            assert manifest.description == 'Test description'
+            assert manifest.levels[0].image == 'debian-13-pve'
+
+    def test_load_nonexistent_raises_error(self):
+        """Should raise error for nonexistent manifest."""
+        from manifest import ManifestLoader
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifests_dir = Path(tmpdir) / 'manifests'
+            manifests_dir.mkdir()
+
+            loader = ManifestLoader(site_config_path=tmpdir)
+
+            with pytest.raises(ConfigError, match='not found'):
+                loader.load('nonexistent')
+
+
+class TestLoadManifestFunction:
+    """Test load_manifest convenience function."""
+
+    def test_load_from_json(self):
+        """Should load from JSON string."""
+        from manifest import load_manifest
+
+        json_str = '{"name": "inline", "levels": [{"name": "l1", "env": "e1"}]}'
+
+        manifest = load_manifest(json_str=json_str)
+
+        assert manifest.name == 'inline'
+
+    def test_depth_limit(self):
+        """Should apply depth limit."""
+        from manifest import load_manifest
+
+        json_str = '''
+        {
+            "name": "deep",
+            "levels": [
+                {"name": "l1", "env": "e1"},
+                {"name": "l2", "env": "e2"},
+                {"name": "l3", "env": "e3"}
+            ]
+        }
+        '''
+
+        manifest = load_manifest(json_str=json_str, depth=2)
+
+        assert manifest.depth == 2
+        assert manifest.levels[0].name == 'l1'
+        assert manifest.levels[1].name == 'l2'
+        # l3 should be truncated
+
+    def test_depth_limit_larger_than_manifest(self):
+        """Depth limit larger than manifest should not change it."""
+        from manifest import load_manifest
+
+        json_str = '{"name": "short", "levels": [{"name": "l1", "env": "e1"}]}'
+
+        manifest = load_manifest(json_str=json_str, depth=5)
+
+        assert manifest.depth == 1  # Not modified

--- a/tests/test_recursive_action.py
+++ b/tests/test_recursive_action.py
@@ -1,0 +1,515 @@
+#!/usr/bin/env python3
+"""Tests for RecursiveScenarioAction.
+
+Tests verify:
+1. Basic execution flow
+2. Context key extraction
+3. SSH command construction
+4. JSON result parsing
+5. Error handling
+6. PTY vs non-PTY modes
+"""
+
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from unittest.mock import patch, MagicMock, Mock
+
+sys.path.insert(0, str(Path(__file__).parent.parent / 'src'))
+
+import pytest
+from common import ActionResult
+
+
+@dataclass
+class MockHostConfig:
+    """Minimal host config for testing."""
+    name: str = 'test-host'
+    ssh_host: str = '10.0.12.100'
+    ssh_user: str = 'root'
+    config_file: Path = Path('/tmp/test.yaml')
+
+
+class TestRecursiveScenarioActionInit:
+    """Test RecursiveScenarioAction initialization."""
+
+    def test_default_values(self):
+        """Should have sensible defaults."""
+        from actions.recursive import RecursiveScenarioAction
+
+        action = RecursiveScenarioAction(name='test', scenario_name='vm-roundtrip')
+
+        assert action.name == 'test'
+        assert action.scenario_name == 'vm-roundtrip'
+        assert action.host_attr == 'inner_ip'
+        assert action.timeout == 600
+        assert action.scenario_args == []
+        assert action.context_keys == []
+        assert action.use_pty is True
+        assert action.ssh_user == 'root'
+
+    def test_custom_values(self):
+        """Should accept custom values."""
+        from actions.recursive import RecursiveScenarioAction
+
+        action = RecursiveScenarioAction(
+            name='custom',
+            scenario_name='pve-setup',
+            host_attr='leaf_ip',
+            timeout=300,
+            scenario_args=['--host', 'nested-pve'],
+            context_keys=['vm_ip', 'vm_id'],
+            use_pty=False,
+            ssh_user='homestak'
+        )
+
+        assert action.host_attr == 'leaf_ip'
+        assert action.timeout == 300
+        assert action.scenario_args == ['--host', 'nested-pve']
+        assert action.context_keys == ['vm_ip', 'vm_id']
+        assert action.use_pty is False
+        assert action.ssh_user == 'homestak'
+
+
+class TestRecursiveScenarioActionRun:
+    """Test RecursiveScenarioAction.run() method."""
+
+    def test_missing_host_key_returns_error(self):
+        """Missing host_key in context should return failure."""
+        from actions.recursive import RecursiveScenarioAction
+
+        action = RecursiveScenarioAction(
+            name='test',
+            scenario_name='vm-roundtrip',
+            host_attr='nonexistent'
+        )
+        config = MockHostConfig()
+        context = {}
+
+        result = action.run(config, context)
+
+        assert result.success is False
+        assert 'nonexistent' in result.message
+
+    def test_success_with_json_result(self):
+        """Successful execution with JSON result should parse correctly."""
+        from actions.recursive import RecursiveScenarioAction
+
+        action = RecursiveScenarioAction(
+            name='test',
+            scenario_name='vm-roundtrip',
+            host_attr='inner_ip',
+            context_keys=['vm_ip']
+        )
+        config = MockHostConfig()
+        context = {'inner_ip': '10.0.12.152'}
+
+        # Mock JSON result from inner scenario
+        json_result = {
+            'scenario': 'vm-roundtrip',
+            'success': True,
+            'duration_seconds': 45.2,
+            'phases': [
+                {'name': 'provision', 'status': 'passed', 'duration': 6.8},
+            ],
+            'context': {
+                'vm_ip': '10.0.12.155',
+                'vm_id': 99900
+            }
+        }
+        mock_output = f"Log line 1\nLog line 2\n{json.dumps(json_result)}"
+
+        with patch.object(action, '_run_with_pty', return_value=(0, mock_output, '')):
+            result = action.run(config, context)
+
+        assert result.success is True
+        assert 'vm-roundtrip' in result.message
+        assert result.context_updates.get('vm_ip') == '10.0.12.155'
+
+    def test_failure_with_error_message(self):
+        """Failed execution should extract error message."""
+        from actions.recursive import RecursiveScenarioAction
+
+        action = RecursiveScenarioAction(
+            name='test',
+            scenario_name='vm-roundtrip',
+            host_attr='inner_ip'
+        )
+        config = MockHostConfig()
+        context = {'inner_ip': '10.0.12.152'}
+
+        json_result = {
+            'scenario': 'vm-roundtrip',
+            'success': False,
+            'error': 'Phase provision failed: tofu apply error',
+            'phases': [
+                {'name': 'provision', 'status': 'failed', 'duration': 3.5},
+            ]
+        }
+        mock_output = json.dumps(json_result)
+
+        with patch.object(action, '_run_with_pty', return_value=(1, mock_output, '')):
+            result = action.run(config, context)
+
+        assert result.success is False
+        assert 'tofu apply error' in result.message
+
+
+class TestBuildRemoteCommand:
+    """Test _build_remote_command method."""
+
+    def test_basic_command(self):
+        """Should build basic homestak command."""
+        from actions.recursive import RecursiveScenarioAction
+
+        action = RecursiveScenarioAction(name='test', scenario_name='vm-roundtrip')
+
+        cmd = action._build_remote_command()
+
+        assert 'homestak' in cmd
+        assert 'scenario' in cmd
+        assert 'vm-roundtrip' in cmd
+        assert '--json-output' in cmd
+
+    def test_with_args(self):
+        """Should include additional arguments."""
+        from actions.recursive import RecursiveScenarioAction
+
+        action = RecursiveScenarioAction(
+            name='test',
+            scenario_name='pve-setup',
+            scenario_args=['--host', 'nested-pve', '--verbose']
+        )
+
+        cmd = action._build_remote_command()
+
+        assert '--host' in cmd
+        assert 'nested-pve' in cmd
+        assert '--verbose' in cmd
+
+
+class TestBuildSSHCommand:
+    """Test _build_ssh_command method."""
+
+    def test_basic_ssh_command(self):
+        """Should build SSH command with standard options."""
+        from actions.recursive import RecursiveScenarioAction
+
+        action = RecursiveScenarioAction(name='test', scenario_name='vm-roundtrip')
+
+        cmd = action._build_ssh_command('10.0.12.152', 'echo hello')
+
+        assert 'ssh' in cmd
+        assert '-o' in cmd
+        assert 'StrictHostKeyChecking=no' in ' '.join(cmd)
+        assert 'root@10.0.12.152' in cmd
+        assert 'echo hello' in cmd
+
+    def test_pty_flag_included(self):
+        """Should include -t flag when use_pty=True."""
+        from actions.recursive import RecursiveScenarioAction
+
+        action = RecursiveScenarioAction(name='test', scenario_name='vm-roundtrip', use_pty=True)
+
+        cmd = action._build_ssh_command('10.0.12.152', 'echo hello')
+
+        assert '-t' in cmd
+
+    def test_no_pty_flag_when_disabled(self):
+        """Should not include -t flag when use_pty=False."""
+        from actions.recursive import RecursiveScenarioAction
+
+        action = RecursiveScenarioAction(name='test', scenario_name='vm-roundtrip', use_pty=False)
+
+        cmd = action._build_ssh_command('10.0.12.152', 'echo hello')
+
+        # Build without PTY, then manually check
+        assert '-t' not in cmd or action.use_pty
+
+    def test_custom_user(self):
+        """Should use custom SSH user."""
+        from actions.recursive import RecursiveScenarioAction
+
+        action = RecursiveScenarioAction(
+            name='test',
+            scenario_name='vm-roundtrip',
+            ssh_user='homestak'
+        )
+
+        cmd = action._build_ssh_command('10.0.12.152', 'echo hello')
+
+        assert 'homestak@10.0.12.152' in cmd
+
+
+class TestParseJSONResult:
+    """Test _parse_json_result method."""
+
+    def test_parse_clean_json(self):
+        """Should parse clean JSON output."""
+        from actions.recursive import RecursiveScenarioAction
+
+        action = RecursiveScenarioAction(name='test', scenario_name='vm-roundtrip')
+
+        json_str = '{"scenario": "vm-roundtrip", "success": true}'
+        result = action._parse_json_result(json_str)
+
+        assert result['scenario'] == 'vm-roundtrip'
+        assert result['success'] is True
+
+    def test_parse_json_after_logs(self):
+        """Should extract JSON from output with preceding log lines."""
+        from actions.recursive import RecursiveScenarioAction
+
+        action = RecursiveScenarioAction(name='test', scenario_name='vm-roundtrip')
+
+        output = """2026-01-21 10:00:00 [INFO] Starting scenario
+Phase: provision... passed
+Phase: start... passed
+{"scenario": "vm-roundtrip", "success": true, "duration_seconds": 45.2}"""
+
+        result = action._parse_json_result(output)
+
+        assert result is not None
+        assert result['scenario'] == 'vm-roundtrip'
+        assert result['success'] is True
+
+    def test_parse_multiline_json(self):
+        """Should parse pretty-printed JSON."""
+        from actions.recursive import RecursiveScenarioAction
+
+        action = RecursiveScenarioAction(name='test', scenario_name='vm-roundtrip')
+
+        output = """Log line
+{
+  "scenario": "vm-roundtrip",
+  "success": true
+}"""
+
+        result = action._parse_json_result(output)
+
+        assert result is not None
+        assert result['success'] is True
+
+    def test_return_none_for_no_json(self):
+        """Should return None when no JSON is found."""
+        from actions.recursive import RecursiveScenarioAction
+
+        action = RecursiveScenarioAction(name='test', scenario_name='vm-roundtrip')
+
+        result = action._parse_json_result("Just some text with no JSON")
+
+        assert result is None
+
+    def test_return_none_for_empty_output(self):
+        """Should return None for empty output."""
+        from actions.recursive import RecursiveScenarioAction
+
+        action = RecursiveScenarioAction(name='test', scenario_name='vm-roundtrip')
+
+        assert action._parse_json_result('') is None
+        assert action._parse_json_result(None) is None
+
+
+class TestExtractContext:
+    """Test _extract_context method."""
+
+    def test_extract_specified_keys(self):
+        """Should extract only specified context keys."""
+        from actions.recursive import RecursiveScenarioAction
+
+        action = RecursiveScenarioAction(
+            name='test',
+            scenario_name='vm-roundtrip',
+            context_keys=['vm_ip', 'vm_id']
+        )
+
+        json_result = {
+            'context': {
+                'vm_ip': '10.0.12.155',
+                'vm_id': 99900,
+                'other_key': 'ignored'
+            }
+        }
+
+        context_updates = action._extract_context(json_result)
+
+        assert context_updates == {'vm_ip': '10.0.12.155', 'vm_id': 99900}
+        assert 'other_key' not in context_updates
+
+    def test_missing_keys_not_included(self):
+        """Should not include keys that don't exist in result."""
+        from actions.recursive import RecursiveScenarioAction
+
+        action = RecursiveScenarioAction(
+            name='test',
+            scenario_name='vm-roundtrip',
+            context_keys=['vm_ip', 'nonexistent']
+        )
+
+        json_result = {
+            'context': {
+                'vm_ip': '10.0.12.155'
+            }
+        }
+
+        context_updates = action._extract_context(json_result)
+
+        assert context_updates == {'vm_ip': '10.0.12.155'}
+        assert 'nonexistent' not in context_updates
+
+    def test_empty_context_keys(self):
+        """Should return empty dict when no keys specified."""
+        from actions.recursive import RecursiveScenarioAction
+
+        action = RecursiveScenarioAction(
+            name='test',
+            scenario_name='vm-roundtrip',
+            context_keys=[]
+        )
+
+        json_result = {
+            'context': {
+                'vm_ip': '10.0.12.155'
+            }
+        }
+
+        context_updates = action._extract_context(json_result)
+
+        assert context_updates == {}
+
+    def test_none_result(self):
+        """Should return empty dict for None result."""
+        from actions.recursive import RecursiveScenarioAction
+
+        action = RecursiveScenarioAction(
+            name='test',
+            scenario_name='vm-roundtrip',
+            context_keys=['vm_ip']
+        )
+
+        assert action._extract_context(None) == {}
+
+
+class TestExtractErrorMessage:
+    """Test _extract_error_message method."""
+
+    def test_error_from_json(self):
+        """Should extract error from JSON result."""
+        from actions.recursive import RecursiveScenarioAction
+
+        action = RecursiveScenarioAction(name='test', scenario_name='vm-roundtrip')
+
+        json_result = {'error': 'Specific error message'}
+
+        error = action._extract_error_message(json_result, '', '')
+
+        assert error == 'Specific error message'
+
+    def test_error_from_failed_phase(self):
+        """Should extract error from failed phase."""
+        from actions.recursive import RecursiveScenarioAction
+
+        action = RecursiveScenarioAction(name='test', scenario_name='vm-roundtrip')
+
+        json_result = {
+            'phases': [
+                {'name': 'provision', 'status': 'passed'},
+                {'name': 'start', 'status': 'failed'}
+            ]
+        }
+
+        error = action._extract_error_message(json_result, '', '')
+
+        assert 'start' in error
+        assert 'failed' in error.lower()
+
+    def test_error_from_stderr(self):
+        """Should extract error from stderr when JSON has no error."""
+        from actions.recursive import RecursiveScenarioAction
+
+        action = RecursiveScenarioAction(name='test', scenario_name='vm-roundtrip')
+
+        error = action._extract_error_message(None, 'Connection refused', '')
+
+        assert 'Connection refused' in error
+
+    def test_error_from_stdout_patterns(self):
+        """Should detect error patterns in stdout."""
+        from actions.recursive import RecursiveScenarioAction
+
+        action = RecursiveScenarioAction(name='test', scenario_name='vm-roundtrip')
+
+        stdout = "Some log\nError: Something went wrong\nMore logs"
+
+        error = action._extract_error_message(None, '', stdout)
+
+        assert 'Error' in error or 'wrong' in error
+
+    def test_fallback_message(self):
+        """Should return fallback message when no error found."""
+        from actions.recursive import RecursiveScenarioAction
+
+        action = RecursiveScenarioAction(name='test', scenario_name='vm-roundtrip')
+
+        error = action._extract_error_message(None, '', '')
+
+        assert 'Unknown error' in error
+
+
+class TestTimeoutHandling:
+    """Test timeout behavior."""
+
+    def test_timeout_returns_failure(self):
+        """Should return failure on timeout."""
+        from actions.recursive import RecursiveScenarioAction
+        import subprocess
+
+        action = RecursiveScenarioAction(
+            name='test',
+            scenario_name='vm-roundtrip',
+            host_attr='inner_ip',
+            timeout=5
+        )
+        config = MockHostConfig()
+        context = {'inner_ip': '10.0.12.152'}
+
+        with patch.object(action, '_run_with_pty', side_effect=subprocess.TimeoutExpired('cmd', 5)):
+            result = action.run(config, context)
+
+        assert result.success is False
+        assert 'Timeout' in result.message
+        assert '5' in result.message
+
+
+class TestNonPTYMode:
+    """Test non-PTY execution mode."""
+
+    def test_run_without_pty(self):
+        """Should execute successfully without PTY."""
+        from actions.recursive import RecursiveScenarioAction
+
+        action = RecursiveScenarioAction(
+            name='test',
+            scenario_name='vm-roundtrip',
+            host_attr='inner_ip',
+            use_pty=False
+        )
+        config = MockHostConfig()
+        context = {'inner_ip': '10.0.12.152'}
+
+        json_result = {
+            'scenario': 'vm-roundtrip',
+            'success': True,
+            'duration_seconds': 30.0
+        }
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = json.dumps(json_result)
+        mock_result.stderr = ''
+
+        with patch('subprocess.run', return_value=mock_result):
+            result = action.run(config, context)
+
+        assert result.success is True


### PR DESCRIPTION
## Summary

Implement Phase 2 of recursive PVE architecture: manifest-driven N-level nested PVE deployments with real-time SSH streaming.

## Type of Change
- [x] New feature

## Changes

### RecursiveScenarioAction (#104)
- PTY allocation for real-time output streaming
- JSON result parsing from `--json-output` scenarios
- Context key extraction for parent scenario consumption

### Manifest Schema (#114)
- `ManifestLevel`, `ManifestSettings` dataclasses in `src/manifest.py`
- YAML loading from `site-config/manifests/`
- JSON serialization for recursive calls via `--manifest-json`
- Depth limiting via `--depth` flag

### Recursive-PVE Scenarios (#114)
- `recursive-pve-constructor`: Build N-level stack per manifest
- `recursive-pve-destructor`: Tear down stack in reverse order
- `recursive-pve-roundtrip`: Constructor + destructor full cycle

### BootstrapAction with serve-repos (#116)
- Reads `HOMESTAK_SOURCE`, `HOMESTAK_TOKEN`, `HOMESTAK_REF` from environment
- Falls back to GitHub URL when serve-repos not configured

### Raw File Serving (#119)
- `serve_raw_file()` in serve-repos.sh extracts files from bare repos via `git show`
- Enables fully offline bootstrap: `install.sh` served from HTTP server
- BootstrapAction fetches `{source_url}/bootstrap.git/install.sh` when HOMESTAK_SOURCE set

### Manifest Settings (#117, #118)
- `timeout_buffer` for recursive timeout adjustment
- `cleanup_on_failure` for failure handling

### Helper Actions
- `InjectSSHKeyAction`: Inject outer host SSH key for leaf VM access
- `InjectSelfSSHKeyAction`: Inject inner host's own SSH key (base64-encoded Python)
- `ConfigureNetworkBridgeAction`: Create vmbr0 from eth0
- `CopySecretsAction`, `GenerateNodeConfigAction`

### Bug Fixes
- Use Python instead of jq for GitHub API tag resolution (jq not installed on fresh PVE)

## Testing

Validated scenarios:
- `recursive-pve-roundtrip --host father --manifest n2-quick` - **283.1s PASSED**
- `nested-pve-roundtrip --host father` - **268.7s PASSED** (regression test)

Unit tests: 56 new tests (27 for RecursiveScenarioAction, 29 for manifest)

## Related Issues

Closes #104, #114, #116, #117, #118, #119
Closes #45 (parent tracking issue)

## PR Readiness Checklist

- [x] Feature tested end-to-end (recursive-pve-roundtrip, nested-pve-roundtrip)
- [x] External tool assumptions verified (SSH streaming, JSON output parsing)
- [x] CHANGELOG entry in this PR
- [x] CLAUDE.md updated (manifest section, new scenarios)
- [x] Integration test scenario identified (recursive-pve-roundtrip)
- [x] Unit tests added (56 tests)