### PR TITLE
feat(preflight): Add provider lockfile validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Added
+- Add provider lockfile validation to preflight checks (#122)
+  - Detects when cached lockfiles in `.states/*/data/` have stale provider versions
+  - Auto-fixes by deleting stale lockfiles (regenerated on next `tofu init`)
+  - Prevents "does not match configured version constraint" errors after Dependabot updates
+  - New functions: `parse_provider_version()`, `parse_lockfile_version()`, `validate_provider_lockfiles()`
+
 ## v0.39 - 2026-01-22
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -544,6 +544,8 @@ Or run with `--dangerously-skip-permissions` flag.
 
 **OpenTofu State Version 4 Bug**: When `TF_DATA_DIR` contains a `terraform.tfstate` file, OpenTofu's legacy code path reads it and rejects valid v4 states with "does not support state version 4". **Workaround**: Store state file outside `TF_DATA_DIR` - we use a `data/` subdirectory for `TF_DATA_DIR` while keeping state at the parent level. See [opentofu/opentofu#3643](https://github.com/opentofu/opentofu/issues/3643).
 
+**Provider Lockfile Mismatch**: When provider version constraints change (e.g., Dependabot updates `providers.tf`), cached lockfiles in `.states/*/data/.terraform.lock.hcl` can have stale versions, causing `tofu init` to fail with "does not match configured version constraint". **Resolution**: Preflight checks now auto-detect and clear stale lockfiles. Manual fix: `rm -rf .states/*/data/.terraform.lock.hcl`.
+
 ## Timeout Configuration
 
 Operations use tiered timeouts based on expected duration. Scenarios can override action defaults.
@@ -750,6 +752,7 @@ Checks include:
 - Bootstrap installation (core repos present)
 - site-init completion (secrets.yaml decrypted, node config exists)
 - PVE API connectivity and token validity
+- Provider lockfile sync (auto-clears stale lockfiles in `.states/`)
 - Nested virtualization (for nested-pve-* scenarios)
 
 **Context File Usage:**


### PR DESCRIPTION
## Summary

Adds preflight check to detect and auto-fix stale provider lockfiles that cause "does not match configured version constraint" errors during `tofu init`.

Closes #122

## Changes

### src/validation.py
- `parse_provider_version()` - extracts version constraint from `tofu/proxmox-vm/providers.tf`
- `parse_lockfile_version()` - extracts provider version from `.terraform.lock.hcl` files
- `validate_provider_lockfiles()` - validates lockfiles, auto-clears stale ones with logging
- Integrated into `run_preflight_checks()` under 'tofu' category
- Integrated into `validate_readiness()` for pre-scenario validation

### tests/test_validation.py
- 13 new test cases across 3 test classes
- Uses dependency injection for test isolation

### Documentation
- CHANGELOG.md - Added entry under Unreleased
- CLAUDE.md - Added to preflight checks list and Known Issues section

## Test Results

```
234 passed in 3.28s
```

All existing tests pass plus 13 new tests for the feature.

## Behavior

When preflight runs:
1. Reads provider version constraint from `tofu/proxmox-vm/providers.tf`
2. Scans `.states/*/data/.terraform.lock.hcl` files
3. If lockfile has different version → auto-deletes the lockfile
4. Logs what was cleared for transparency

This prevents the "version mismatch" errors that occur after Dependabot updates provider versions.

## Test plan

- [x] Unit tests pass (234 tests)
- [ ] Run `--preflight --local` to verify check runs
- [ ] Run `vm-roundtrip` to verify integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)